### PR TITLE
Feat/apt #11

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/AptController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/AptController.java
@@ -1,0 +1,38 @@
+package com.myapt.domain.apt.controller;
+
+import com.myapt.domain.apt.dto.AptInfo;
+import com.myapt.domain.apt.service.AptService;
+import com.myapt.global.template.ResTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/apt")
+public class AptController {
+    private final AptService aptService;
+
+    // AptService를 생성자 주입 방식으로 주입받습니다.
+    public AptController(AptService aptService) {
+        this.aptService = aptService;
+    }
+
+
+    @GetMapping("/info")
+    // @Operation(
+    // 	summary = "특정 아파트 기본 정보 조회",
+    // 	description = "선택한 아파트 기본 정보를 조회합니다.",
+    // 	security = {},
+    // 	responses = {
+    // 		@ApiResponse(responseCode = "200", description = "선택한 아파트 기본 정보 조회 성공"),
+    // 		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    // 		@ApiResponse(responseCode = "500", description = "서버 오류")
+    // 	}
+    // )
+    public ResTemplate<AptInfo> getAptInfo(@RequestParam String aptsId) {
+        AptInfo aptInfo = aptService.getApartmentInfo(aptsId);
+        return new ResTemplate<>(HttpStatus.OK, "아파트 기본 정보 조회 성공", aptInfo);
+    }
+}

--- a/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
@@ -1,0 +1,70 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record AptInfo( // 클라이언트에 아파트의 기본정보를 반환할 때 사용됩니다.
+                       String name, // 아파트 명
+                       String buildingType, // 건물 종류
+                       String roadAddress, // 도로명 주소
+                       String zipCode, // 우편 번호
+                       String completionDate, // 준공일
+                       String developer, // 시행사
+                       String constructor, // 시공사
+                       long numberOfUnits, // 세대수
+                       // List<SalePriceInfo> salePrices, // 면적별 매매가
+                       Map<String, Long> monthlyMaintenanceFees, // 월별 관리비
+                       List<String> amenities, // 부대복리시설을 List로 변경
+                       String buildingStructure, // 건물구조
+                       String managementType, // 관리방식
+                       String heatingType, // 난방방식
+                       long cctvCount, // CCTV 대수(대)
+                       long totalParkingSpaces, // 총주차 대수(대)
+                       String managementOfficeAddress, // 관리사무소 주소
+                       String managementOfficeContact, // 관리사무소 연락처
+                       String managementOfficeFax, // 관리사무소 팩스
+                       String housingManager // 주택관리업자
+) {
+    @Builder
+    public static record SalePriceInfo(long area, long price) {
+        // SalePriceInfo 레코드는 AptInfo의 속성 중 하나인 salePrices를 구성하는 요소입니다. 이 레코드는 각 아파트의 면적과 해당 면적의 매매가를 표현하기 위해 사용됩니다.
+    }
+
+    // of 메서드는 인자를 받아 ApartmentDetailInfo 객체를 생성하는데, 이는 DTO 객체를 생성하여 클라이언트로 반환할 때 유용합니다.
+    public static AptInfo of(
+            String name, String buildingType, String roadAddress, String zipCode, String completionDate,
+            String developer, String constructor, long numberOfUnits,
+            // List<SalePriceInfo> salePrices,
+            Map<String, Long> monthlyMaintenanceFees,
+            List<String> amenities, // Map에서 List로 변경
+            String buildingStructure, String managementType, String heatingType, long cctvCount,
+            long totalParkingSpaces, String managementOfficeAddress, String managementOfficeContact,
+            String managementOfficeFax, String housingManager
+    ) {
+        return AptInfo.builder()
+                .name(name)
+                .buildingType(buildingType)
+                .roadAddress(roadAddress)
+                .zipCode(zipCode)
+                .completionDate(completionDate)
+                .developer(developer)
+                .constructor(constructor)
+                .numberOfUnits(numberOfUnits)
+                //.salePrices(salePrices)
+                .monthlyMaintenanceFees(monthlyMaintenanceFees)
+                .amenities(amenities) // List로 된 amenities를 사용
+                .buildingStructure(buildingStructure)
+                .managementType(managementType)
+                .heatingType(heatingType)
+                .cctvCount(cctvCount)
+                .totalParkingSpaces(totalParkingSpaces)
+                .managementOfficeAddress(managementOfficeAddress)
+                .managementOfficeContact(managementOfficeContact)
+                .managementOfficeFax(managementOfficeFax)
+                .housingManager(housingManager)
+                .build();
+    }
+}

--- a/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
+++ b/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
@@ -1,0 +1,266 @@
+package com.myapt.domain.apt.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "DetailApts")
+public class DetailApts {
+
+    @Id
+    // @GeneratedValue(strategy = GenerationType.IDENTITY) 외부에서 id 입력 받음
+    @Column(name = "detail_apts_id")
+    private String id; //아파트 관리코드(단지코드)
+
+    @Column(name = "complex_type")
+    private String complexType; // 단지분류
+
+    @Column(name = "postal_code")
+    private String postalCode; // 우편번호
+
+    @Column(name = "road_address")
+    private String roadAddress; // 도로명 주소
+
+    @Column(name = "sale_type")
+    private String saleType; // 분양형태
+
+    @Column(name = "approval_date")
+    private String approvalDate; // 사용승인일
+
+    @Column(name = "registration_date")
+    private String registrationDate; // 등록일
+
+    @Column(name = "number_of_buildings")
+    private Long numberOfBuildings; // 동 수
+
+    @Column(name = "number_of_units")
+    private Long numberOfUnits; // 세대 수
+
+    @Column(name = "number_of_sale_units")
+    private Long numberOfSaleUnits; // 분양 세대 수
+
+    @Column(name = "number_of_rent_units")
+    private Long numberOfRentUnits; // 임대 세대 수
+
+    @Column(name = "number_of_public_rent_units")
+    private Long numberOfPublicRentUnits; // 공공임대 세대 수
+
+    @Column(name = "number_of_private_rent_units")
+    private Long numberOfPrivateRentUnits; // 민간임대 세대 수
+
+    @Column(name = "management_type")
+    private String managementType; // 관리 형태
+
+    @Column(name = "heating_type")
+    private String heatingType; // 난방 형태
+
+    @Column(name = "corridor_type")
+    private String corridorType; // 복도 형태
+
+    @Column(name = "constructor")
+    private String constructor; // 시공사
+
+    @Column(name = "developer")
+    private String developer; // 개발사
+
+    @Column(name = "housing_manager")
+    private String housingManager; // 주택 관리자
+
+    @Column(name = "housing_manager_business_registration_number")
+    private String housingManagerBusinessRegistrationNumber; // 주택 관리자 사업자등록번호
+
+    @Column(name = "general_management_type")
+    private String generalManagementType; // 일반 관리 형태
+
+    @Column(name = "general_management_staff")
+    private Long generalManagementStaff; // 일반 관리 인원
+
+    @Column(name = "security_management_type")
+    private String securityManagementType; // 경비 관리 형태
+
+    @Column(name = "security_management_staff")
+    private Long securityManagementStaff; // 경비 관리 인원
+
+    @Column(name = "security_management_contractor")
+    private String securityManagementContractor; // 경비 관리 용역
+
+    @Column(name = "cleaning_management_type")
+    private String cleaningManagementType; // 청소 관리 형태
+
+    @Column(name = "cleaning_management_staff")
+    private Long cleaningManagementStaff; // 청소 관리 인원
+
+    @Column(name = "cleaning_management_contractor")
+    private String cleaningManagementContractor; // 청소 관리 용역
+
+    @Column(name = "food_waste_disposal_method")
+    private String foodWasteDisposalMethod; // 음식물 쓰레기 처리 방법
+
+    @Column(name = "disinfection_management_type")
+    private String disinfectionManagementType; // 소독 관리 형태
+
+    @Column(name = "disinfection_management_contractor")
+    private String disinfectionManagementContractor; // 소독 관리 용역
+
+    @Column(name = "annual_disinfection_frequency")
+    private Long annualDisinfectionFrequency; // 연간 소독 횟수
+
+    @Column(name = "disinfection_method")
+    private String disinfectionMethod; // 소독 방법
+
+    @Column(name = "building_structure")
+    private String buildingStructure; // 건물 구조
+
+    @Column(name = "electricity_supply_capacity")
+    private Long electricitySupplyCapacity; // 전기 공급 용량
+
+    @Column(name = "electricity_contract_type_per_unit")
+    private String electricityContractTypePerUnit; // 세대별 전기 계약 유형
+
+    @Column(name = "electricity_safety_manager_assigned")
+    private Boolean electricitySafetyManagerAssigned; // 전기 안전 관리자 배정 여부
+
+    @Column(name = "fire_receiver_type")
+    private String fireReceiverType; // 화재 수신기 유형(화재수신반방식)
+
+    @Column(name = "water_supply_method")
+    private String waterSupplyMethod; // 급수 방식
+
+    @Column(name = "elevator_management_type")
+    private String elevatorManagementType; // 엘리베이터 관리 형태
+
+    @Column(name = "passenger_elevator_count")
+    private Long passengerElevatorCount; // 승용 엘리베이터 수
+
+    @Column(name = "cargo_elevator_count")
+    private Long cargoElevatorCount; // 화물 엘리베이터 수
+
+    @Column(name = "passenger_cargo_elevator_count")
+    private Long passengerCargoElevatorCount; // 승용/화물 겸용 엘리베이터 수
+
+    @Column(name = "disabled_elevator_count")
+    private Long disabledElevatorCount; // 장애인용 엘리베이터 수
+
+    @Column(name = "emergency_elevator_count")
+    private Long emergencyElevatorCount; // 비상용 엘리베이터 수
+
+    @Column(name = "other_elevator_count")
+    private Long otherElevatorCount; // 기타 엘리베이터 수
+
+    @Column(name = "total_parking_spaces")
+    private Long totalParkingSpaces; // 총 주차 공간 수
+
+    @Column(name = "ground_parking_spaces")
+    private Long groundParkingSpaces; // 지상 주차 공간 수
+
+    @Column(name = "underground_parking_spaces")
+    private Long undergroundParkingSpaces; // 지하 주차 공간 수
+
+    @Column(name = "cctv_count")
+    private Long cctvCount; // CCTV 수
+
+    @Column(name = "home_network")
+    private Boolean homeNetwork; // 홈 네트워크
+
+    @Column(name = "emergency_vehicle_accessible_gate")
+    private Boolean emergencyVehicleAccessibleGate; // 비상 차량 출입 가능 게이트
+
+    @Column(name = "selected_gate_parking_control_system")
+    private String selectedGateParkingControlSystem; // 선택 게이트 주차 제어 시스템
+
+    @Column(name = "emergency_license_plate_recognition")
+    private Boolean emergencyLicensePlateRecognition; // 비상 차량 번호판 인식
+
+    @Column(name = "emergency_vehicle_access_method")
+    private String emergencyVehicleAccessMethod; // 비상 차량 출입 방법
+
+    @Column(name = "emergency_vehicle_instant_pass")
+    private Boolean emergencyVehicleInstantPass; // 비상 차량 즉시 통과
+
+    @Column(name = "management_office_address")
+    private String managementOfficeAddress; // 관리 사무소 주소
+
+    @Column(name = "management_office_contact")
+    private String managementOfficeContact; // 관리 사무소 연락처
+
+    @Column(name = "management_office_fax")
+    private String managementOfficeFax; // 관리 사무소 팩스
+
+    @Column(name = "amenities")
+    private String amenities; // 편의 시설(부대복리시설)
+
+    @Column(name = "max_floor_count")
+    private Long maxFloorCount; // 최대 층 수(최고층수)
+
+    @Column(name = "max_floor_count_building_register")
+    private Long maxFloorCountBuildingRegister; // 건축물 등록 최대 층 수
+
+    @Column(name = "basement_floor_count")
+    private Long basementFloorCount; // 지하 층 수
+
+    @Column(name = "total_vehicle_count")
+    private Long totalVehicleCount; // 총 차량 수(차량보유대수-전체)
+
+    @Column(name = "electric_vehicle_count")
+    private Long electricVehicleCount; // 전기차 수(차량보유대수-전기차)
+
+    @Column(name = "ground_ev_charger_installed")
+    private Boolean groundEvChargerInstalled; // 지상 전기차 충전기 설치 여부
+
+    @Column(name = "underground_ev_charger_installed")
+    private Boolean undergroundEvChargerInstalled; // 지하 전기차 충전기 설치 여부
+
+    @Column(name = "ground_ev_parking_spaces")
+    private Long groundEvParkingSpaces; // 지상 전기차 주차 공간 수
+
+    @Column(name = "underground_ev_parking_spaces")
+    private Long undergroundEvParkingSpaces; // 지하 전기차 주차 공간 수
+
+    @Column(name = "ground_accessible_to_public")
+    private Boolean groundAccessibleToPublic; // 지상 공공 접근 가능 여부
+
+    @Column(name = "underground_accessible_to_public")
+    private Boolean undergroundAccessibleToPublic; // 지하 공공 접근 가능 여부
+
+    @Column(name = "ground_access_start_time")
+    private String groundAccessStartTime; // 지상 접근 시작 시간
+
+    @Column(name = "underground_access_start_time")
+    private String undergroundAccessStartTime; // 지하 접근 시작 시간
+
+    @Column(name = "ground_access_end_time")
+    private String groundAccessEndTime; // 지상 접근 종료 시간
+
+    @Column(name = "underground_access_end_time")
+    private String undergroundAccessEndTime; // 지하 접근 종료 시간
+
+    @Column(name = "ev_charging_facilities_details")
+    private String evChargingFacilitiesDetails; // 전기차 충전 시설 상세
+
+    @Column(name = "ground_ev_charger_count")
+    private Long groundEvChargerCount; // 지상 전기차 충전기 수
+
+    @Column(name = "underground_ev_charger_count")
+    private Long undergroundEvChargerCount; // 지하 전기차 충전기 수
+
+    @Column(name = "resident_facilities")
+    private String residentFacilities; // 주민 시설(입주편의시설)
+
+    // 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "apts_id")
+    private Apts apts;
+
+    //연관관계
+    @OneToMany(mappedBy = "detailApts", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MngCost> mngCosts;
+
+}

--- a/src/main/java/com/myapt/domain/apt/entity/MngCost.java
+++ b/src/main/java/com/myapt/domain/apt/entity/MngCost.java
@@ -1,0 +1,173 @@
+package com.myapt.domain.apt.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "MngCost")
+public class MngCost {
+
+    @Id
+    @Column(name = "mngcost_id", nullable = false)
+    private String id; // 관리비 ID
+
+    @Column(name = "Province")
+    private String province; // 도
+
+    @Column(name = "CityCountyDistrict")
+    private String cityCountyDistrict; // 시/군/구
+
+    @Column(name = "TownVillage")
+    private String townVillage; // 읍/면/동
+
+    @Column(name = "Street")
+    private String street; // 거리
+
+    @Column(name = "ComplexName")
+    private String complexName; // 단지명
+
+    @Column(name = "OccurrenceYearMonth")
+    private Long occurrenceYearMonth; // 발생 연월 ---------------------------- 중요 -----------------------
+    // [아파트 단지코드 & 발생 연월]을 기본키로 해서, 월별 관리비를 조회해야한다.
+
+    @Column(name = "IndividualUsageSum", nullable = false)
+    private Long individualUsageSum; // 개별 사용 합계
+
+    @Column(name = "HeatingCost_Common")
+    private Long heatingCostCommon; // 난방비 공용
+
+    @Column(name = "HeatingCost_Individual")
+    private Long heatingCostIndividual; // 난방비 개별
+
+    @Column(name = "HotWaterCost_Common")
+    private Long hotWaterCostCommon; // 온수비 공용
+
+    @Column(name = "HotWaterCost_Individual")
+    private Long hotWaterCostIndividual; // 온수비 개별
+
+    @Column(name = "GasUsageCost_Common")
+    private Long gasUsageCostCommon; // 가스비 공용
+
+    @Column(name = "GasUsageCost_Individual")
+    private Long gasUsageCostIndividual; // 가스비 개별
+
+    @Column(name = "ElectricityCost_Common")
+    private Long electricityCostCommon; // 전기비 공용
+
+    @Column(name = "ElectricityCost_Individual")
+    private Long electricityCostIndividual; // 전기비 개별
+
+    @Column(name = "WaterCost_Common")
+    private Long waterCostCommon; // 수도비 공용
+
+    @Column(name = "WaterCost_Individual")
+    private Long waterCostIndividual; // 수도비 개별
+
+    @Column(name = "TVFee")
+    private Long tvFee; // TV 수신료
+
+    @Column(name = "SewageFee")
+    private Long sewageFee; // 하수도비
+
+    @Column(name = "WasteFee")
+    private Long wasteFee; // 쓰레기 처리비
+
+    @Column(name = "AssociationCost")
+    private Long associationCost; // 조합비
+
+    @Column(name = "BuildingInsuranceFee")
+    private Long buildingInsuranceFee; // 건물 보험료
+
+    @Column(name = "ElectionCost")
+    private Long electionCost; // 선거비
+
+    @Column(name = "etc")
+    private Long etc; // 기타 비용
+
+    @Column(name = "ReserveFundMonthlyCharge")
+    private Long reserveFundMonthlyCharge; // 예비비 월별 청구액 (장충금)
+
+    @Column(name = "ReserveFundMonthlyExpenditure")
+    private Long reserveFundMonthlyExpenditure; // 예비비 월별 지출액
+
+    @Column(name = "ReserveFundTotalAccumulated")
+    private Long reserveFundTotalAccumulated; // 예비비 총 누적액
+
+    @Column(name = "ReserveFundAccumulationRate")
+    private Long reserveFundAccumulationRate; // 예비비 누적률
+
+    @Column(name = "MiscellaneousIncomeMonthlyAmount")
+    private Long miscellaneousIncomeMonthlyAmount; // 잡수입 월별 금액
+
+    @Column(name = "ResidentContributionRevenue")
+    private Long residentContributionRevenue; // 주민 기여 수익
+
+    @Column(name = "CommonContributionRevenue")
+    private Long commonContributionRevenue; // 공용 기여 수익
+
+    @Column(name = "TotalCommonManagementFeeSum", nullable = false)
+    private Long totalCommonManagementFeeSum; // 총 공용 관리비 합계
+
+    @Column(name = "LaborCost")
+    private Long laborCost; // 인건비
+
+    @Column(name = "OfficeExpenses")
+    private Long officeExpenses; // 사무비
+
+    @Column(name = "TaxesAndDues")
+    private Long taxesAndDues; // 세금 및 공과금
+
+    @Column(name = "ClothingCost")
+    private Long clothingCost; // 의류비
+
+    @Column(name = "TrainingCost")
+    private Long trainingCost; // 교육비
+
+    @Column(name = "VehicleMaintenanceCost")
+    private Long vehicleMaintenanceCost; // 차량 유지비
+
+    @Column(name = "OtherIncidentalExpenses")
+    private Long otherIncidentalExpenses; // 기타 부대비용
+
+    @Column(name = "CleaningCost")
+    private Long cleaningCost; // 청소비
+
+    @Column(name = "SecurityCost")
+    private Long securityCost; // 경비비
+
+    @Column(name = "DisinfectionCost")
+    private Long disinfectionCost; // 소독비
+
+    @Column(name = "ElevatorMaintenanceCost")
+    private Long elevatorMaintenanceCost; // 엘리베이터 유지비
+
+    @Column(name = "IntelligentNetworkMaintenance")
+    private Long intelligentNetworkMaintenance; // 지능형 네트워크 유지비
+
+    @Column(name = "RepairCost")
+    private Long repairCost; // 수리비
+
+    @Column(name = "FacilityMaintenanceCost")
+    private Long facilityMaintenanceCost; // 시설 유지비
+
+    @Column(name = "SafetyInspectionCost")
+    private Long safetyInspectionCost; // 안전 검사비
+
+    @Column(name = "DisasterPreventionCost")
+    private Long disasterPreventionCost; // 재해 예방비
+
+    @Column(name = "ManagementCommissionFee")
+    private Long managementCommissionFee; // 관리 수수료
+
+    // 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "detail_apts_id")
+    private DetailApts detailApts; // 아파트 상세 ID
+
+}

--- a/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
@@ -1,10 +1,12 @@
 package com.myapt.domain.apt.repository;
 
+import com.myapt.domain.apt.entity.Apts;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.myapt.domain.apt.entity.Apts;
+import java.util.Optional;
 
 @Repository
 public interface AptRepository extends JpaRepository<Apts, Long> {
+    Optional<Apts> findById(String aptsId);
 }

--- a/src/main/java/com/myapt/domain/apt/repository/DetailAptsRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/DetailAptsRepository.java
@@ -1,0 +1,13 @@
+package com.myapt.domain.apt.repository;
+
+import com.myapt.domain.apt.entity.DetailApts;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DetailAptsRepository extends JpaRepository<DetailApts, String> {
+    // apts.id (즉, apts_id)에 해당하는 DetailApts 객체를 찾는 메서드
+    Optional<DetailApts> findByApts_Id(String aptsId);
+}

--- a/src/main/java/com/myapt/domain/apt/repository/MngCostRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/MngCostRepository.java
@@ -1,0 +1,12 @@
+package com.myapt.domain.apt.repository;
+
+import com.myapt.domain.apt.entity.MngCost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MngCostRepository extends JpaRepository<MngCost, String> {
+    List<MngCost> findByDetailAptsId(String id);
+}

--- a/src/main/java/com/myapt/domain/apt/service/AptService.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptService.java
@@ -1,0 +1,7 @@
+package com.myapt.domain.apt.service;
+
+import com.myapt.domain.apt.dto.AptInfo;
+
+public interface AptService {
+    AptInfo getApartmentInfo(String aptsId);
+}

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -1,0 +1,78 @@
+package com.myapt.domain.apt.service;
+
+import com.myapt.domain.apt.dto.AptInfo;
+import com.myapt.domain.apt.entity.Apts;
+import com.myapt.domain.apt.entity.DetailApts;
+import com.myapt.domain.apt.entity.MngCost;
+import com.myapt.domain.apt.repository.AptRepository;
+import com.myapt.domain.apt.repository.DetailAptsRepository;
+import com.myapt.domain.apt.repository.MngCostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AptServiceImpl implements AptService{
+    private final AptRepository aptRepository;
+    private final DetailAptsRepository detailAptsRepository;
+    private final MngCostRepository mngCostRepository;
+
+    @Override
+    public AptInfo getApartmentInfo(String aptsId) {
+        // #1. apts_id 를 사용해서, Apts 와 DetailApts의 리포지토리들로 부터 아파트 기본정보들을 받아온다.
+        Apts apts = aptRepository.findById(aptsId).orElseThrow(() -> new RuntimeException("Apts not found"));
+        DetailApts detailApts = detailAptsRepository.findByApts_Id(aptsId).orElseThrow(() -> new RuntimeException("DetailApts not found"));
+
+        // #2. detail_apts_id(아파트 관리비코드)에 해당하는 월별 관리비를 계산 및 나머지 요소들과 함께 아파트기본정보를 반환하는 코드
+        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailApts.getId());
+
+        // #3. 세대수 가져오기
+        long numberOfUnits = apts.getNmhsh();
+
+        // #4. 월별 관리비 계산 (세대수 이용)
+        Map<String, Long> monthlyMaintenanceFees = mngCosts.stream()
+                .collect(Collectors.toMap(
+                        mngCost -> String.valueOf(mngCost.getOccurrenceYearMonth()),
+                        mngCost -> {
+                            long individualUsageSumPerUnit = mngCost.getIndividualUsageSum() / numberOfUnits;
+                            long reserveFundMonthlyChargePerUnit = mngCost.getReserveFundMonthlyCharge() / numberOfUnits;
+                            long totalCommonManagementFeeSumPerUnit = mngCost.getTotalCommonManagementFeeSum() / numberOfUnits;
+
+                            return individualUsageSumPerUnit + reserveFundMonthlyChargePerUnit + totalCommonManagementFeeSumPerUnit;
+                        }
+                ));
+
+        // #5. amenities 문자열을 List<String>으로 변환
+        List<String> amenitiesList = Arrays.stream(detailApts.getAmenities().split(","))
+                .map(String::trim) // 각 요소의 앞뒤 공백 제거
+                .collect(Collectors.toList());
+
+        // #6. AptInfo DTO 객체를 생성해서 모든 정보를 담는다.
+        return AptInfo.of(
+                apts.getAptNm(),
+                detailApts.getComplexType(),
+                apts.getRdnmadr(),
+                detailApts.getPostalCode(),
+                String.valueOf(apts.getUseAprvYear()),
+                detailApts.getDeveloper(),
+                detailApts.getConstructor(),
+                numberOfUnits,
+                monthlyMaintenanceFees,
+                amenitiesList, // List<String>으로 전달
+                apts.getBuldStru(),
+                detailApts.getManagementType(),
+                detailApts.getHeatingType(),
+                detailApts.getCctvCount(),
+                detailApts.getTotalParkingSpaces(),
+                detailApts.getManagementOfficeAddress(),
+                detailApts.getManagementOfficeContact(),
+                detailApts.getManagementOfficeFax(),
+                detailApts.getHousingManager()
+        );
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #11 
## 💬 리뷰 포인트
> 아파트 정보 - 아파트 기본 정보 조회 API
## 🚀 상세 설명
> 아파트 기본 정보를 조회하는 API 구현
가.  사용자가 원하는 특정 아파트의 마커를 선택시에, 조회되는 기본 정보들을 반환
나. 추가적으로 월별 관리비 데이터를 제공하기 위해, MngCost 리포지토리가 필요
다. 월별 관리비 데이터를 계산하는 방식은 
= 공용관리비계/세대수 + 개별 사용료계/세대수 + 장충금 월부과액/ 세대수
## 📸 스크린
아파트 기본 정보 조회 - 성공
![스크린샷 2025-01-30 200544](https://github.com/user-attachments/assets/9623a4dd-1621-4c34-b37a-74b21f6099ed)
![스크린샷 2025-01-30 200553](https://github.com/user-attachments/assets/35d061a2-e1a6-4a98-bb8e-1aa27f1f4d17)

## 📢 노트