### PR TITLE
Feat/apt #17

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/AptController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/AptController.java
@@ -2,6 +2,7 @@ package com.myapt.domain.apt.controller;
 
 import com.myapt.domain.apt.dto.AptInfo;
 import com.myapt.domain.apt.dto.AptInfoDetail;
+import com.myapt.domain.apt.dto.MngCostInfo;
 import com.myapt.domain.apt.service.AptService;
 import com.myapt.global.template.ResTemplate;
 import org.springframework.http.HttpStatus;
@@ -51,5 +52,22 @@ public class AptController {
     public ResTemplate<AptInfoDetail> getAptInfoDetail(@RequestParam String detail_apts_id) { //아파트 관리비 코드(기본키)로 조회
         AptInfoDetail aptInfoDetail = aptService.getApartmentInfoDetail(detail_apts_id);
         return new ResTemplate<>(HttpStatus.OK, "아파트 상세 정보 조회 성공", aptInfoDetail);
+    }
+
+    @GetMapping("/feeDetail")
+    // @Operation(
+    // 	summary = "특정 아파트 관리비 정보 상세조회",
+    // 	description = "관리비 정보를 상세조회합니다.",
+    // 	security = {},
+    // 	responses = {
+    // 		@ApiResponse(responseCode = "200", description = "관리비 정보 상세 조회 성공"),
+    // 		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    // 		@ApiResponse(responseCode = "404", description = "해당 관리비 상세 정보가 존재하지 않습니다."),
+    // 		@ApiResponse(responseCode = "500", description = "서버 오류")
+    // 	}
+    // )
+    public ResTemplate<MngCostInfo> getMngCostInfo(@RequestParam String detail_apts_id) { //아파트 관리비 코드(기본키)로 조회
+        MngCostInfo mngCostInfo = aptService.getMngCostInfoDetail(detail_apts_id);
+        return new ResTemplate<>(HttpStatus.OK, "관리비 상세 정보 조회 성공", mngCostInfo);
     }
 }

--- a/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
@@ -1,0 +1,86 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record MngCostInfo(
+        // 공용관리비 상세 내역
+        List<MonthlyCommonManagementFee> monthlyTotalCommonManagementFeeSum,
+
+        // 개별사용료 상세 내역
+        List<MonthlyIndividualManagementFee> monthlyTotalIndividualManagementFeeSum,
+
+        // 장충금 월부과액 상세 내역
+        Map<Long, Long> reserveFundMonthlyCharge,
+
+        // 장충금 월사용액 상세 내역
+        Map<Long, Long> reserveFundMonthlyExpenditure,
+
+        // 장충금 총적립금액 상세 내역
+        Map<Long, Long> reserveFundTotalAccumulated,
+
+        // 장충금 적립율 상세 내역
+        Map<Long, Long> reserveFundAccumulationRate,
+
+        // 잡수입 월수입금액 상세 내역
+        List<MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmount
+) {
+
+    @Builder
+    public static record MonthlyCommonManagementFee(
+            long occurrenceYearMonth, // 월
+            long laborCost, // 인건비
+            long officeExpenses, // 제사무비
+            long taxesAndDues, // 제세공과금
+            long clothingCost, // 피복비
+            long trainingCost, // 교육훈련비
+            long vehicleMaintenanceCost, // 차량유지비
+            long otherIncidentalExpenses, // 그 밖의 부대비용
+            long cleaningCost, // 청소비
+            long securityCost, // 경비비
+            long disinfectionCost, // 소독비
+            long elevatorMaintenanceCost, // 승강기 유지비
+            long intelligentNetworkMaintenance, // 지능형 네트워크 유지비
+            long repairCost, // 수선비
+            long facilityMaintenanceCost, // 시설유지비
+            long safetyInspectionCost, // 안전 점검비
+            long disasterPreventionCost, // 재해예방비
+            long managementCommissionFee // 위탁관리 수수료
+    ) {
+    }
+
+    @Builder
+    public static record MonthlyIndividualManagementFee(
+            long occurrenceYearMonth, // 월
+            long heatingCostCommon, // 난방비(공용)
+            long heatingCostIndividual, // 난방비(전용)
+            long hotWaterCostCommon, // 급탕비(공용)
+            long hotWaterCostIndividual, // 급탕비(전용)
+            long gasUsageCostCommon, // 가스사용료(공용)
+            long gasUsageCostIndividual, // 가스사용료(전용)
+            long electricityCostCommon, // 전기료(공용)
+            long electricityCostIndividual, // 전기료(전용)
+            long waterCostCommon, // 수도료(공용)
+            long waterCostIndividual, // 수도료(전용)
+            long tvFee, // TV 수신료
+            long sewageFee, // 정화조 오물 수수료
+            long wasteFee, // 생활폐기물 수수료
+            long associationCost, // 입대의 운영비
+            long buildingInsuranceFee, // 건물 보험료
+            long electionCost, // 선관위 운영비
+            long etcFee // 기타
+    ) {
+    }
+
+    @Builder
+    public static record MiscellaneousIncomeMonthlyAmount(
+            long occurrenceYearMonth, // 월
+            long miscellaneousIncomeMonthlyAmount, // 잡수입 월수입금액
+            long residentContributionRevenue, // 입주자 기여수익
+            long commonContributionRevenue // 공동 기여수익
+    ) {
+    }
+}

--- a/src/main/java/com/myapt/domain/apt/entity/MngCost.java
+++ b/src/main/java/com/myapt/domain/apt/entity/MngCost.java
@@ -33,8 +33,7 @@ public class MngCost {
     private String complexName; // 단지명
 
     @Column(name = "OccurrenceYearMonth")
-    private Long occurrenceYearMonth; // 발생 연월 ---------------------------- 중요 -----------------------
-    // [아파트 단지코드 & 발생 연월]을 기본키로 해서, 월별 관리비를 조회해야한다.
+    private Long occurrenceYearMonth; // 발생 연월
 
     @Column(name = "IndividualUsageSum", nullable = false)
     private Long individualUsageSum; // 개별 사용 합계

--- a/src/main/java/com/myapt/domain/apt/service/AptService.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptService.java
@@ -2,8 +2,10 @@ package com.myapt.domain.apt.service;
 
 import com.myapt.domain.apt.dto.AptInfoDetail;
 import com.myapt.domain.apt.dto.AptInfo;
+import com.myapt.domain.apt.dto.MngCostInfo;
 
 public interface AptService {
     AptInfo getApartmentInfo(String aptsId);
     AptInfoDetail getApartmentInfoDetail(String detailAptsId);
+    MngCostInfo getMngCostInfoDetail(String detailAptsId);
 }

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -1,7 +1,8 @@
 package com.myapt.domain.apt.service;
 
-import com.myapt.domain.apt.dto.AptInfoDetail;
 import com.myapt.domain.apt.dto.AptInfo;
+import com.myapt.domain.apt.dto.AptInfoDetail;
+import com.myapt.domain.apt.dto.MngCostInfo;
 import com.myapt.domain.apt.entity.Apts;
 import com.myapt.domain.apt.entity.DetailApts;
 import com.myapt.domain.apt.entity.MngCost;
@@ -10,8 +11,10 @@ import com.myapt.domain.apt.repository.DetailAptsRepository;
 import com.myapt.domain.apt.repository.MngCostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.LinkedHashMap;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -110,4 +113,125 @@ public class AptServiceImpl implements AptService{
                 detailApts.getGeneralManagementStaff() // 일반 관리 인원
         );
     }
+
+    @Override
+    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
+        // #1. detailAptsId를 사용하여 MngCost 리포지토리로부터 해당 아파트 관리비 상세정보들을 받아온다.
+        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
+
+        // #2. MngCostInfo DTO 객체를 생성하여 모든 정보를 담는다.
+
+        // #2-2 월별 공용관리비 상세 내역을 리스트로 변환
+        List<MngCostInfo.MonthlyCommonManagementFee> monthlyCommonManagementFeeList = mngCosts.stream()
+                .map(mngCost -> new MngCostInfo.MonthlyCommonManagementFee(
+                        mngCost.getOccurrenceYearMonth(), // 발생 년월로 수정
+                        mngCost.getLaborCost(),
+                        mngCost.getOfficeExpenses(),
+                        mngCost.getTaxesAndDues(),
+                        mngCost.getClothingCost(),
+                        mngCost.getTrainingCost(),
+                        mngCost.getVehicleMaintenanceCost(),
+                        mngCost.getOtherIncidentalExpenses(),
+                        mngCost.getCleaningCost(),
+                        mngCost.getSecurityCost(),
+                        mngCost.getDisinfectionCost(),
+                        mngCost.getElevatorMaintenanceCost(),
+                        mngCost.getIntelligentNetworkMaintenance(),
+                        mngCost.getRepairCost(),
+                        mngCost.getFacilityMaintenanceCost(),
+                        mngCost.getSafetyInspectionCost(),
+                        mngCost.getDisasterPreventionCost(),
+                        mngCost.getManagementCommissionFee()
+                ))
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyCommonManagementFee::occurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toList());
+
+        // #2-3 월별 개별관리비 상세 내역을 리스트로 변환
+        List<MngCostInfo.MonthlyIndividualManagementFee> monthlyIndividualManagementFeeList = mngCosts.stream()
+                .map(mngCost -> new MngCostInfo.MonthlyIndividualManagementFee(
+                        mngCost.getOccurrenceYearMonth(), // 발생 년월로 수정
+                        mngCost.getHeatingCostCommon(),
+                        mngCost.getHeatingCostIndividual(),
+                        mngCost.getHotWaterCostCommon(),
+                        mngCost.getHotWaterCostIndividual(),
+                        mngCost.getGasUsageCostCommon(),
+                        mngCost.getGasUsageCostIndividual(),
+                        mngCost.getElectricityCostCommon(),
+                        mngCost.getElectricityCostIndividual(),
+                        mngCost.getWaterCostCommon(),
+                        mngCost.getWaterCostIndividual(),
+                        mngCost.getTvFee(),
+                        mngCost.getSewageFee(),
+                        mngCost.getWasteFee(),
+                        mngCost.getAssociationCost(),
+                        mngCost.getBuildingInsuranceFee(),
+                        mngCost.getElectionCost(),
+                        mngCost.getEtc()
+                ))
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyIndividualManagementFee::occurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toList());
+
+        // #2-4 월별 잡수입 상세 내역을 리스트로 변환
+        List<MngCostInfo.MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmountList = mngCosts.stream()
+                .map(mngCost -> new MngCostInfo.MiscellaneousIncomeMonthlyAmount(
+                        mngCost.getOccurrenceYearMonth(), // 발생 년월로 수정
+                        mngCost.getMiscellaneousIncomeMonthlyAmount(),
+                        mngCost.getResidentContributionRevenue(),
+                        mngCost.getCommonContributionRevenue()
+                ))
+                .sorted(Comparator.comparing(MngCostInfo.MiscellaneousIncomeMonthlyAmount::occurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toList());
+
+        // #2-5 장충금 월부과액 상세 내역을 Map으로 변환 (월별 부과액)
+        Map<Long, Long> reserveFundMonthlyCharge = mngCosts.stream()
+                .sorted(Comparator.comparing(MngCost::getOccurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toMap(
+                        MngCost::getOccurrenceYearMonth,
+                        MngCost::getReserveFundMonthlyCharge,
+                        (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new
+                ));
+
+        // #2-6 장충금 월사용액 상세 내역을 Map으로 변환 (월별 사용액)
+        Map<Long, Long> reserveFundMonthlyExpenditure = mngCosts.stream()
+                .sorted(Comparator.comparing(MngCost::getOccurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toMap(
+                        MngCost::getOccurrenceYearMonth,
+                        MngCost::getReserveFundMonthlyExpenditure,
+                        (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new
+                ));
+
+        // #2-7 장충금 총적립금액 상세 내역을 Map으로 변환 (월별 총적립액)
+        Map<Long, Long> reserveFundTotalAccumulated = mngCosts.stream()
+                .sorted(Comparator.comparing(MngCost::getOccurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toMap(
+                        MngCost::getOccurrenceYearMonth,
+                        MngCost::getReserveFundTotalAccumulated,
+                        (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new
+                ));
+
+        // #2-8 장충금 적립율 상세 내역을 Map으로 변환 (월별 적립률)
+        Map<Long, Long> reserveFundAccumulationRate = mngCosts.stream()
+                .sorted(Comparator.comparing(MngCost::getOccurrenceYearMonth)) // 오름차순 정렬
+                .collect(Collectors.toMap(
+                        MngCost::getOccurrenceYearMonth,
+                        MngCost::getReserveFundAccumulationRate,
+                        (oldValue, newValue) -> oldValue,
+                        LinkedHashMap::new
+                ));
+
+        // #3. MngCostInfo DTO를 빌드하여 모든 정보를 담아 반환
+        return MngCostInfo.builder()
+                .monthlyTotalCommonManagementFeeSum(monthlyCommonManagementFeeList) // 공용관리비 상세
+                .monthlyTotalIndividualManagementFeeSum(monthlyIndividualManagementFeeList) // 개별관리비 상세
+                .reserveFundMonthlyCharge(reserveFundMonthlyCharge) // 장충금 월부과액
+                .reserveFundMonthlyExpenditure(reserveFundMonthlyExpenditure) // 장충금 월사용액
+                .reserveFundTotalAccumulated(reserveFundTotalAccumulated) // 장충금 총적립금액
+                .reserveFundAccumulationRate(reserveFundAccumulationRate) // 장충금 적립율
+                .miscellaneousIncomeMonthlyAmount(miscellaneousIncomeMonthlyAmountList) // 잡수입 월수입금액
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #17 
## 💬 리뷰 포인트
>아파트 조회 - 특정 아파트 관리비 상세내역 조회 API 구현
## 🚀 상세 설명
> 아파트 기본 정보 조회시, 월별 관리비 영역의 '자세히보기' 클릭 시에
월별 관리비 계산 시 사용된 관리비 항목들에 대한 자세한 내용의 값들을 반환함
## 📸 스크린샷
![스크린샷 2025-01-31 000915](https://github.com/user-attachments/assets/bc9d9be2-b002-44e4-bf61-101c8743786d)
![스크린샷 2025-01-31 000940](https://github.com/user-attachments/assets/cd9b08ca-b2bf-454b-9ef5-05a19cc6880d)
![스크린샷 2025-01-31 001010](https://github.com/user-attachments/assets/34face5f-6042-4ce9-ab87-ee5f5c62105d)
![스크린샷 2025-01-31 001021](https://github.com/user-attachments/assets/b2ac84c3-d5e0-4cc2-9eaa-994504f1f808)

## 📢 노트