### PR TITLE
[FEAT] 메인 관련 API 구현

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/AptController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/AptController.java
@@ -2,11 +2,20 @@ package com.myapt.domain.apt.controller;
 
 import com.myapt.domain.apt.dto.AptInfo;
 import com.myapt.domain.apt.dto.AptInfoDetail;
+import com.myapt.domain.apt.dto.MainResponse;
 import com.myapt.domain.apt.dto.MngCostInfo;
+import com.myapt.domain.apt.dto.NoticeInfo;
+import com.myapt.domain.apt.dto.NoticeRequest;
+import com.myapt.domain.apt.dto.NoticeResponse;
 import com.myapt.domain.apt.service.AptService;
 import com.myapt.global.template.ResTemplate;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +28,57 @@ public class AptController {
     // AptService를 생성자 주입 방식으로 주입받습니다.
     public AptController(AptService aptService) {
         this.aptService = aptService;
+    }
+
+    @GetMapping("main")
+    // @Operation(
+    // 	summary = "메인화면 조회",
+    // 	description = "메인화면 정보를 조회합니다.",
+    // 	security = {},
+    // 	responses = {
+    // 		@ApiResponse(responseCode = "200", description = "메인화면 정보 로딩완료"),
+    // 		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    //      @ApiResponse(responseCode = "404", description = "항목에 누락이 발생하였습니다."),
+    // 		@ApiResponse(responseCode = "500", description = "서버 오류")
+    // 	}
+    // )
+    public ResTemplate<MainResponse> getMainInfo() {
+        MainResponse data = aptService.getMainInfo();
+        return new ResTemplate<>(HttpStatus.OK, "메인화면 조회 성공", data);
+    }
+
+    @PostMapping("/notice")
+    // @Operation(
+    // 	summary = "공지사항 목록 조회",
+    // 	description = "공지사항 목록을 조회합니다..",
+    // 	security = {},
+    // 	responses = {
+    // 		@ApiResponse(responseCode = "200", description = "공지사항 목록 로딩완료"),
+    // 		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    //      @ApiResponse(responseCode = "404", description = "공지사항이 존재하지 않습니다."),
+    // 		@ApiResponse(responseCode = "500", description = "서버 오류")
+    // 	}
+    // )
+    public ResTemplate<NoticeResponse> getNoticeList(@RequestBody NoticeRequest noticeRequest) {
+        NoticeResponse data = aptService.getNotices(noticeRequest);
+        return new ResTemplate<>(HttpStatus.OK, "공지사항 조회 성공", data);
+    }
+
+    @GetMapping("/notice/{id}")
+    // @Operation(
+    // 	summary = "공지사항 조회",
+    // 	description = "공지사항를 조회합니다..",
+    // 	security = {},
+    // 	responses = {
+    // 		@ApiResponse(responseCode = "200", description = "공지사항 로딩완료"),
+    // 		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    //      @ApiResponse(responseCode = "404", description = "해당 공지사항이 존재하지 않습니다."),
+    // 		@ApiResponse(responseCode = "500", description = "서버 오류")
+    // 	}
+    // )
+    public ResTemplate<NoticeInfo> getNoticeList(@PathVariable Long id) {
+        NoticeInfo data = aptService.getNotice(id);
+        return new ResTemplate<>(HttpStatus.OK, "공지사항 조회 성공", data);
     }
 
     @GetMapping("/info")
@@ -69,5 +129,12 @@ public class AptController {
     public ResTemplate<MngCostInfo> getMngCostInfo(@RequestParam String detail_apts_id) { //아파트 관리비 코드(기본키)로 조회
         MngCostInfo mngCostInfo = aptService.getMngCostInfoDetail(detail_apts_id);
         return new ResTemplate<>(HttpStatus.OK, "관리비 상세 정보 조회 성공", mngCostInfo);
+    }
+
+    // 구성요소가 빠졌을 경우 400으로 처리하기 위해서 생성
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ResTemplate<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ResTemplate<Void> response = new ResTemplate<>(HttpStatus.BAD_REQUEST, ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/myapt/domain/apt/controller/MapController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/MapController.java
@@ -1,0 +1,33 @@
+package com.myapt.domain.apt.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.myapt.domain.apt.dto.MapMarkerInfo;
+import com.myapt.domain.apt.service.MapService;
+import com.myapt.global.template.ResTemplate;
+
+@RestController
+@RequestMapping("/map")
+public class MapController {
+	private final MapService mapService;
+
+	public MapController(MapService mapService) {
+		this.mapService = mapService;
+	}
+
+	@GetMapping("/building")
+	public ResTemplate<List<MapMarkerInfo>> getMapMarkers(
+		@RequestParam double minLa,
+		@RequestParam double minLo,
+		@RequestParam double maxLa,
+		@RequestParam double maxLo) {
+		List<MapMarkerInfo> data = mapService.getMapMarkers(minLa, minLo, maxLa, maxLo);
+		return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/LowestMgmtFeeAptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/LowestMgmtFeeAptInfo.java
@@ -1,0 +1,16 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record LowestMgmtFeeAptInfo(
+	String address,
+	String name
+) {
+	public static LowestMgmtFeeAptInfo of(String address, String name) {
+		return LowestMgmtFeeAptInfo.builder()
+			.address(address)
+			.name(name)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/MainResponse.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MainResponse.java
@@ -1,0 +1,21 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MainResponse(
+	Long aptAvgPrice,
+	Long aptCount,
+	Long plannedAptCount,
+	LowestMgmtFeeAptInfo lowestMgmtFeeAptInfo
+
+) {
+	public static MainResponse of(Long aptAvgPrice, Long aptCount, Long plannedAptCount, LowestMgmtFeeAptInfo lowestMgmtFeeAptInfo) {
+		return MainResponse.builder()
+			.aptAvgPrice(aptAvgPrice)
+			.aptCount(aptCount)
+			.plannedAptCount(plannedAptCount)
+			.lowestMgmtFeeAptInfo(lowestMgmtFeeAptInfo)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/MapMarkerInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MapMarkerInfo.java
@@ -1,0 +1,20 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MapMarkerInfo(
+	String buildingId,
+	String buildingName,
+	Double latitude,
+	Double longitude
+) {
+	public static MapMarkerInfo of(String buildingId, String buildingName, Double latitude, Double longitude) {
+		return MapMarkerInfo.builder()
+			.buildingId(buildingId)
+			.buildingName(buildingName)
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/NoticeInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/NoticeInfo.java
@@ -1,0 +1,24 @@
+package com.myapt.domain.apt.dto;
+
+import java.time.LocalDateTime;
+
+import com.myapt.global.util.TimeUtils;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeInfo(
+	Long id, // 공지 id
+	String title, // 공지 제목
+	String content, // 공지 내용
+	String createAt // 공지 날짜
+) {
+	public static NoticeInfo of(Long id, String title, String content, LocalDateTime createAt) {
+		return NoticeInfo.builder()
+			.id(id)
+			.title(title)
+			.content(content)
+			.createAt(TimeUtils.formatTimeDifference(createAt))
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/NoticeRequest.java
+++ b/src/main/java/com/myapt/domain/apt/dto/NoticeRequest.java
@@ -1,0 +1,16 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeRequest(
+	Integer num, // 가져올 요소 갯수
+	Integer pages // 페이지 번호
+) {
+	public static NoticeRequest of(Integer pages, Integer num) {
+		return NoticeRequest.builder()
+			.num(num)
+			.pages(pages)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/NoticeResponse.java
+++ b/src/main/java/com/myapt/domain/apt/dto/NoticeResponse.java
@@ -1,0 +1,18 @@
+package com.myapt.domain.apt.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeResponse(
+	List<NoticeInfo> notices,
+	Long totalElements
+) {
+	public static NoticeResponse of(List<NoticeInfo> notices, Long totalElements) {
+		return NoticeResponse.builder()
+			.notices(notices)
+			.totalElements(totalElements)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/entity/Notices.java
+++ b/src/main/java/com/myapt/domain/apt/entity/Notices.java
@@ -1,0 +1,38 @@
+package com.myapt.domain.apt.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notices {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notices_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String title; // 제목
+
+	@Column(nullable = false)
+	private String content; // 내용
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	public LocalDateTime getCreateAt() {
+		return createdAt;
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/exception/MarkerNotFoundException.java
+++ b/src/main/java/com/myapt/domain/apt/exception/MarkerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.myapt.domain.apt.exception;
+
+public class MarkerNotFoundException extends NoticeNotFoundException{
+	public MarkerNotFoundException(String message) {
+		super(message);
+	}
+
+	public MarkerNotFoundException() {
+		super("해당 좌표 내 마커가 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/myapt/domain/apt/exception/NoticeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.myapt.domain.apt.exception;
+
+import com.myapt.global.error.exception.NotFoundGroupException;
+
+public class NoticeNotFoundException extends NotFoundGroupException {
+	public NoticeNotFoundException(String message) {
+		super(message);
+	}
+
+	public NoticeNotFoundException() {
+		super("가져올 공지사항이 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
@@ -4,9 +4,11 @@ import com.myapt.domain.apt.entity.Apts;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AptRepository extends JpaRepository<Apts, Long> {
     Optional<Apts> findById(String aptsId);
+    List<Apts> findByLaBetweenAndLoBetween(double minLa, double maxLa, double minLo, double maxLo);
 }

--- a/src/main/java/com/myapt/domain/apt/repository/NoticeRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/NoticeRepository.java
@@ -1,0 +1,13 @@
+package com.myapt.domain.apt.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.myapt.domain.apt.entity.Notices;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notices, Long> {
+	Optional<Notices> findById(Long id);
+}

--- a/src/main/java/com/myapt/domain/apt/service/AptService.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptService.java
@@ -2,9 +2,16 @@ package com.myapt.domain.apt.service;
 
 import com.myapt.domain.apt.dto.AptInfoDetail;
 import com.myapt.domain.apt.dto.AptInfo;
+import com.myapt.domain.apt.dto.MainResponse;
 import com.myapt.domain.apt.dto.MngCostInfo;
+import com.myapt.domain.apt.dto.NoticeInfo;
+import com.myapt.domain.apt.dto.NoticeRequest;
+import com.myapt.domain.apt.dto.NoticeResponse;
 
 public interface AptService {
+    MainResponse getMainInfo();
+    NoticeInfo getNotice(Long id);
+    NoticeResponse getNotices(NoticeRequest noticeRequest);
     AptInfo getApartmentInfo(String aptsId);
     AptInfoDetail getApartmentInfoDetail(String detailAptsId);
     MngCostInfo getMngCostInfoDetail(String detailAptsId);

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -2,15 +2,28 @@ package com.myapt.domain.apt.service;
 
 import com.myapt.domain.apt.dto.AptInfo;
 import com.myapt.domain.apt.dto.AptInfoDetail;
+import com.myapt.domain.apt.dto.LowestMgmtFeeAptInfo;
+import com.myapt.domain.apt.dto.MainResponse;
 import com.myapt.domain.apt.dto.MngCostInfo;
+import com.myapt.domain.apt.dto.NoticeInfo;
+import com.myapt.domain.apt.dto.NoticeRequest;
+import com.myapt.domain.apt.dto.NoticeResponse;
 import com.myapt.domain.apt.entity.Apts;
 import com.myapt.domain.apt.entity.DetailApts;
 import com.myapt.domain.apt.entity.MngCost;
+import com.myapt.domain.apt.entity.Notices;
+import com.myapt.domain.apt.exception.NoticeNotFoundException;
 import com.myapt.domain.apt.repository.AptRepository;
 import com.myapt.domain.apt.repository.DetailAptsRepository;
 import com.myapt.domain.apt.repository.MngCostRepository;
+import com.myapt.domain.apt.repository.NoticeRepository;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
 import java.util.LinkedHashMap;
 
 import java.util.Arrays;
@@ -25,6 +38,65 @@ public class AptServiceImpl implements AptService{
     private final AptRepository aptRepository;
     private final DetailAptsRepository detailAptsRepository;
     private final MngCostRepository mngCostRepository;
+    private final NoticeRepository noticeRepository;
+
+    @Override
+    public MainResponse getMainInfo() {
+        List<Apts> aptsList = aptRepository.findAll();
+
+        Long aptAvgPrice = 685000000L; // 향후 DB에서 받아오도록 수정
+        Long plannedAptCount = 87L;
+        String lowestAptAddress = "울산시 북구 화봉동"; // 향후 DB에서 받아오도록 수정
+        String lowestAptName = "행남아파트"; // 향후 DB에서 받아오도록 수정
+
+       return MainResponse.of(
+           aptAvgPrice,
+		   (long)aptsList.size(), // 아파트 개수
+           plannedAptCount,
+           LowestMgmtFeeAptInfo.of(
+               lowestAptAddress,
+               lowestAptName
+           )
+       );
+    }
+    @Override
+    public NoticeInfo getNotice(Long id) {
+        if (id == null) { throw new IllegalArgumentException("id 항목이 누락되었습니다."); }
+        Notices notice = noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException());
+        return NoticeInfo.of(
+            notice.getId(),
+            notice.getTitle(),
+            notice.getContent(),
+            notice.getCreateAt()
+        );
+    }
+
+    @Override
+    public NoticeResponse getNotices(NoticeRequest noticeRequest) {
+        Integer pages = noticeRequest.pages();
+        Integer num = noticeRequest.num();
+
+        if (num == null) { throw new IllegalArgumentException("num 항목이 누락되었습니다."); }
+        if (pages == null) { throw new IllegalArgumentException("pages 항목이 누락되었습니다."); }
+        List<Notices> notices = noticeRepository.findAll(
+            PageRequest.of(pages, num, Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
+
+        // 공지 사항 없을 경우 404
+        if (notices.isEmpty()) {
+            throw new NoticeNotFoundException();
+        }
+
+        List<NoticeInfo> noticeInfoList = notices.stream()
+            .map(notice -> NoticeInfo.of(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent().length() > 100 ? notice.getContent().substring(0, 100) : notice.getContent(), // 100자 제한
+                notice.getCreateAt()
+            ))
+            .collect(Collectors.toList());
+
+        return NoticeResponse.of(noticeInfoList, noticeRepository.count());
+    }
 
     @Override
     public AptInfo getApartmentInfo(String aptsId) {

--- a/src/main/java/com/myapt/domain/apt/service/MapService.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapService.java
@@ -1,0 +1,9 @@
+package com.myapt.domain.apt.service;
+
+import java.util.List;
+
+import com.myapt.domain.apt.dto.MapMarkerInfo;
+
+public interface MapService {
+	public List<MapMarkerInfo> getMapMarkers(double minLa, double minLo, double maxLa, double maxLo);
+}

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -1,0 +1,36 @@
+package com.myapt.domain.apt.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.myapt.domain.apt.dto.MapMarkerInfo;
+import com.myapt.domain.apt.exception.MarkerNotFoundException;
+import com.myapt.domain.apt.repository.AptRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MapServiceImpl implements MapService {
+	private final AptRepository aptRepository;
+
+	@Override
+	public List<MapMarkerInfo> getMapMarkers(double minLa, double minLo, double maxLa, double maxLo) {
+		List<MapMarkerInfo> markers = aptRepository.findByLaBetweenAndLoBetween(minLa, maxLa, minLo, maxLo)
+			.stream()
+			.map(building -> MapMarkerInfo.of(
+				building.getId(),
+				building.getAptNm(),
+				building.getLa(),
+				building.getLo()))
+			.collect(Collectors.toList());
+
+		if (markers.isEmpty()) {
+			throw new MarkerNotFoundException();
+		}
+
+		return markers;
+	}
+}

--- a/src/main/java/com/myapt/global/util/TimeUtils.java
+++ b/src/main/java/com/myapt/global/util/TimeUtils.java
@@ -1,0 +1,27 @@
+package com.myapt.global.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class TimeUtils {
+	public static String formatTimeDifference(LocalDateTime dateTime) {
+		LocalDateTime now = LocalDateTime.now();
+		Duration duration = Duration.between(dateTime, now);
+
+		if (duration.toMinutes() < 1) {
+			return "방금 전";
+		} else if (duration.toMinutes() < 60) {
+			return duration.toMinutes() + "분 전";
+		} else if (duration.toHours() < 24) {
+			return duration.toHours() + "시간 전";
+		} else if (duration.toDays() < 7) {
+			return duration.toDays() + "일 전";
+		} else if (duration.toDays() < 30) {
+			return (duration.toDays() / 7) + "주 전";
+		} else if (duration.toDays() < 365) {
+			return (duration.toDays() / 30) + "달 전";
+		} else {
+			return (duration.toDays() / 365) + "년 전";
+		}
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #20
## 💬 리뷰 포인트
> 메인관련 API 1개를 제외한 4개 구현
## 🚀 상세 설명
> 메인관련 API - `메인화면 정보, 공지사항 목록 조회, 공지사항 상세 조회, 지도 마커 불러오기`
## 📸 스크린샷
(추가 예정)
(현재는 코드리뷰 위주로 봐주세요)

## 📢 노트