### PR TITLE
[REFACTOR] 뉴스 관련 수정사항

### DIFF
--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 import java.util.ArrayList;

--- a/src/main/java/com/myapt/domain/news/controller/NewsController.java
+++ b/src/main/java/com/myapt/domain/news/controller/NewsController.java
@@ -4,10 +4,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.myapt.domain.news.dto.NewsPageRequest;
 import com.myapt.domain.news.dto.NewsResponse;
 import com.myapt.domain.news.service.NewsServiceImpl;
 import com.myapt.global.template.ResTemplate;
@@ -21,16 +24,15 @@ import lombok.RequiredArgsConstructor;
 public class NewsController {
 	private final NewsServiceImpl newsService;
 
-	@GetMapping("/{type}")
+	@PostMapping("/{type}")
 	public ResTemplate<NewsResponse> getNews(
 			@PathVariable String type,
-			@RequestParam("pages") int pages,
-			@RequestParam("sort") String sort) {
+			@RequestBody NewsPageRequest newsPageRequest) {
 		NewsResponse data;
 		if (type.equals("general")) {
-			data = newsService.getNews("부실 아파트", pages, 8, sort);
+			data = newsService.getNews("아파트", newsPageRequest.pages(), newsPageRequest.num(), newsPageRequest.sort());
 		} else {
-			data = newsService.getNews("부실 아파트", pages, 8, sort);
+			data = newsService.getNews("부실 아파트", newsPageRequest.pages(), newsPageRequest.num(), newsPageRequest.sort());
 		}
 		return new ResTemplate<>(HttpStatus.OK, "뉴스 조회 성공", data);
 	}

--- a/src/main/java/com/myapt/domain/news/dto/NewsPageRequest.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsPageRequest.java
@@ -1,0 +1,18 @@
+package com.myapt.domain.news.dto;
+
+import lombok.Builder;
+
+@Builder
+public record NewsPageRequest(
+	Integer num, // 가져올 요소 갯수
+	Integer pages, // 페이지 번호
+	String sort // 정렬 방식
+) {
+	public static NewsPageRequest of(Integer pages, Integer num, String sort) {
+		return NewsPageRequest.builder()
+			.num(num)
+			.pages(pages)
+			.sort(sort)
+			.build();
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #13

## 💬 리뷰 포인트
API 재사용성을 위해 프론트에서 뉴스 데이터를 받아올 수 있는 갯수를 프론트에서 정할 수 있도록 수정해달라 함.
그리고 QueryString으로 정했던 page, sort 등 정보도 POST Body에 담아서 보낼 수 있도록 요청.

## 🚀 상세 설명
GET 메서드였던 뉴스 불러오기를 POST로 변경

## 📸 스크린샷
<img width="334" alt="image" src="https://github.com/user-attachments/assets/07ac1ccf-20d4-4dc8-8065-63c5bb5280f9" />

## 📢 노트