### PR TITLE
Feat/apt #15

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record AptInfoDetail(
     Building building, // 건물 정보
     PropertyInfo propertyInfo, // 추가 정보
+    AccessibleToPublic accessibleToPublic, // 외부인 개방 여부 정보
     Parking parking, // 주차 정보
     EvCharging evCharging, // 전기차 충전 정보
     DisinfectionManagement disinfectionManagement, // 소독 관리 정보
@@ -19,6 +20,7 @@ public record AptInfoDetail(
     public static AptInfoDetail of(
         long maxFloorCount, long basementFloorCount, long passengerCargoElevatorCount, String buildingStructure,
         String approvalDate, String developer, String constructor, long numberOfUnits,
+        boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic,
         long groundParkingSpaces, long undergroundParkingSpaces,
         long groundEvChargerCount, long undergroundEvChargerCount, long groundEvParkingSpaces,
         long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails,
@@ -30,6 +32,7 @@ public record AptInfoDetail(
         return new AptInfoDetail(
             new Building(maxFloorCount, basementFloorCount, passengerCargoElevatorCount, buildingStructure),
             new PropertyInfo(approvalDate, developer, constructor, numberOfUnits),
+            new AccessibleToPublic(groundAccessibleToPublic, undergroundAccessibleToPublic),
             new Parking(groundParkingSpaces, undergroundParkingSpaces),
             new EvCharging(groundEvChargerCount, undergroundEvChargerCount, groundEvParkingSpaces, undergroundEvParkingSpaces, evChargingFacilitiesDetails),
             new DisinfectionManagement(disinfectionManagementType, disinfectionManagementContractor, annualDisinfectionFrequency),
@@ -44,6 +47,9 @@ public record AptInfoDetail(
 
     // 추가 정보를 나타내는 클래스입니다.
     public record PropertyInfo(String approvalDate, String developer, String constructor, long numberOfUnits) {}
+
+    // 외부인 개방 여부 정보를 나타내는 클래스입니다.
+    public record AccessibleToPublic(boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic) {}
 
     // 주차 정보를 나타내는 클래스입니다.
     public record Parking(long groundParkingSpaces, long undergroundParkingSpaces) {}

--- a/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
@@ -52,7 +52,7 @@ public record AptInfoDetail(
     public record EvCharging(long groundEvChargerCount, long undergroundEvChargerCount, long groundEvParkingSpaces, long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails) {}
 
     // 전기차 충전 시설 상세 정보를 나타내는 클래스입니다.
-    public record EvChargingFacilityDetail(String location, String type, String connector, String chargingSpeed, int count, String provider) {}
+    public record EvChargingFacilityDetail(String location, String type, String connector, String chargingSpeed, long count, String provider) {}
 
     // 소독 관리 정보를 나타내는 클래스입니다.
     public record DisinfectionManagement(String managementType, String contractor, long annualFrequency) {}

--- a/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
+++ b/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
@@ -225,10 +225,10 @@ public class DetailApts {
     private Long undergroundEvParkingSpaces; // 지하 전기차 주차 공간 수
 
     @Column(name = "ground_accessible_to_public")
-    private Boolean groundAccessibleToPublic; // 지상 공공 접근 가능 여부
+    private Boolean groundAccessibleToPublic; // 외부인개방여부(지상)
 
     @Column(name = "underground_accessible_to_public")
-    private Boolean undergroundAccessibleToPublic; // 지하 공공 접근 가능 여부
+    private Boolean undergroundAccessibleToPublic; // 외부인개방여부(지하)
 
     @Column(name = "ground_access_start_time")
     private String groundAccessStartTime; // 지상 접근 시작 시간

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -146,41 +146,49 @@ public class AptServiceImpl implements AptService{
     @Override
     public AptInfoDetail getApartmentInfoDetail(String detailAptsId) {
         // #1. apts_id 를 사용해서 DetailApts의 리포지토리로부터 아파트 상세정보들을 받아온다.
-        DetailApts detailApts = detailAptsRepository.findById(detailAptsId).orElseThrow(() -> new RuntimeException("DetailApts not found"));
+        DetailApts detailApts = detailAptsRepository.findById(detailAptsId)
+                .orElseThrow(() -> new RuntimeException("해당 아파트 상세정보가 서버에 존재하지 않습니다."));
 
-        // 전기차 충전 시설 상세 정보를 문자열로 받아옵니다. (예: "◆1◆|지하|스탠드형충전기|AC단상 5핀|완속|2|kepco|,◆2◆|지하|스탠드형충전기|AC3상 7핀|급속|1|kepco|")
+        // 전기차 충전 시설 상세 정보를 문자열로 받아옵니다.
         String evChargingDetailsString = detailApts.getEvChargingFacilitiesDetails();
         // 문자열을 파싱하여 리스트를 채웁니다.
-        List<AptInfoDetail.EvChargingFacilityDetail> evChargingFacilitiesDetails = parseEvChargingDetails(evChargingDetailsString);
+        List<AptInfoDetail.EvChargingFacilityDetail> evChargingFacilitiesDetails = parseEvChargingDetails(
+                evChargingDetailsString != null ? evChargingDetailsString : "");
 
         // #2. AptInfoDetail DTO 객체를 생성해서 모든 정보를 담는다.
         return AptInfoDetail.of(
-                detailApts.getMaxFloorCount(),
-                detailApts.getBasementFloorCount(),
-                detailApts.getPassengerCargoElevatorCount(), // 승용&화물 엘레베이터 수
-                detailApts.getBuildingStructure(), // 건물구조
-                detailApts.getApprovalDate(), // 사용승인일 (준공일)
-                detailApts.getDeveloper(), // 시행사
-                detailApts.getConstructor(), // 시공사
-                detailApts.getNumberOfUnits(), // 세대수
-                detailApts.getGroundParkingSpaces(), // 지상 주차 공간 수
-                detailApts.getUndergroundParkingSpaces(), // 지하 주차 공간 수
-                detailApts.getGroundEvChargerCount(), // 지상 전기차 충전기 수
-                detailApts.getUndergroundEvChargerCount(), // 지하 전기차 충전기 수
-                detailApts.getGroundEvParkingSpaces(), // 지상 전기차 주차 공간 수
-                detailApts.getUndergroundEvParkingSpaces(), // 지하 전기차 주차 공간 수
-                evChargingFacilitiesDetails, // 전기차 충전 시설 상세
-                detailApts.getDisinfectionManagementType(), // 소독 관리 형태
-                detailApts.getDisinfectionManagementContractor(), // 소독 관리 용역
-                detailApts.getAnnualDisinfectionFrequency(), // 연간 소독 횟수
-                detailApts.getSecurityManagementType(), // 경비 관리 형태
-                detailApts.getSecurityManagementContractor(), // 경비 관리 용역
-                detailApts.getSecurityManagementStaff(), // 경비 관리 인원
-                detailApts.getCleaningManagementType(), // 청소 관리 형태
-                detailApts.getCleaningManagementContractor(), // 청소 관리 용역
-                detailApts.getFoodWasteDisposalMethod(), // 음식물 쓰레기 처리 방법
-                detailApts.getGeneralManagementStaff() // 일반 관리 인원
+                defaultIfNull(detailApts.getMaxFloorCount(), 0L),
+                defaultIfNull(detailApts.getBasementFloorCount(), 0L),
+                defaultIfNull(detailApts.getPassengerCargoElevatorCount(), 0L),
+                defaultIfNull(detailApts.getBuildingStructure(), ""),
+                defaultIfNull(detailApts.getApprovalDate(), ""),
+                defaultIfNull(detailApts.getDeveloper(), ""),
+                defaultIfNull(detailApts.getConstructor(), ""),
+                defaultIfNull(detailApts.getNumberOfUnits(), 0L),
+                defaultIfNull(detailApts.getGroundAccessibleToPublic(), false), // 외부인 개방 여부(지상) 추가
+                defaultIfNull(detailApts.getUndergroundAccessibleToPublic(), false), // 외부인 개방 여부(지하) 추가
+                defaultIfNull(detailApts.getGroundParkingSpaces(), 0L),
+                defaultIfNull(detailApts.getUndergroundParkingSpaces(), 0L),
+                defaultIfNull(detailApts.getGroundEvChargerCount(), 0L),
+                defaultIfNull(detailApts.getUndergroundEvChargerCount(), 0L),
+                defaultIfNull(detailApts.getGroundEvParkingSpaces(), 0L),
+                defaultIfNull(detailApts.getUndergroundEvParkingSpaces(), 0L),
+                evChargingFacilitiesDetails,
+                defaultIfNull(detailApts.getDisinfectionManagementType(), ""),
+                defaultIfNull(detailApts.getDisinfectionManagementContractor(), ""),
+                defaultIfNull(detailApts.getAnnualDisinfectionFrequency(), 0L),
+                defaultIfNull(detailApts.getSecurityManagementType(), ""),
+                defaultIfNull(detailApts.getSecurityManagementContractor(), ""),
+                defaultIfNull(detailApts.getSecurityManagementStaff(), 0L),
+                defaultIfNull(detailApts.getCleaningManagementType(), ""),
+                defaultIfNull(detailApts.getCleaningManagementContractor(), ""),
+                defaultIfNull(detailApts.getFoodWasteDisposalMethod(), ""),
+                defaultIfNull(detailApts.getGeneralManagementStaff(), 0L)
         );
+    }
+    // defaultIfNull 메소드를 사용하여 위에서 각 필드를 검사하고, null인 경우 기본 값을 반환하도록 했다.
+    private <T> T defaultIfNull(T value, T defaultValue) {
+        return value != null ? value : defaultValue;
     }
 
     @Override

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -1,13 +1,6 @@
 package com.myapt.domain.apt.service;
 
-import com.myapt.domain.apt.dto.AptInfo;
-import com.myapt.domain.apt.dto.AptInfoDetail;
-import com.myapt.domain.apt.dto.LowestMgmtFeeAptInfo;
-import com.myapt.domain.apt.dto.MainResponse;
-import com.myapt.domain.apt.dto.MngCostInfo;
-import com.myapt.domain.apt.dto.NoticeInfo;
-import com.myapt.domain.apt.dto.NoticeRequest;
-import com.myapt.domain.apt.dto.NoticeResponse;
+import com.myapt.domain.apt.dto.*;
 import com.myapt.domain.apt.entity.Apts;
 import com.myapt.domain.apt.entity.DetailApts;
 import com.myapt.domain.apt.entity.MngCost;
@@ -17,21 +10,12 @@ import com.myapt.domain.apt.repository.AptRepository;
 import com.myapt.domain.apt.repository.DetailAptsRepository;
 import com.myapt.domain.apt.repository.MngCostRepository;
 import com.myapt.domain.apt.repository.NoticeRepository;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -334,7 +318,7 @@ public class AptServiceImpl implements AptService{
                     String type = parts[1]; // 충전기 타입
                     String connector = parts[2]; // 커넥터 타입
                     String chargingSpeed = parts[3]; // 충전 속도
-                    int count = Integer.parseInt(parts[4]); // 충전기 대수
+                    long count = Integer.parseInt(parts[4]); // 충전기 대수
                     String provider = parts[5]; // 공급자
                     // 객체 생성
                     AptInfoDetail.EvChargingFacilityDetail detail = new AptInfoDetail.EvChargingFacilityDetail(


### PR DESCRIPTION
## 📌 이슈 번호
> #15 
## 💬 리뷰 포인트
> 아파트 정보 - 아파트 상세정보 조회 API 관련 - 리펙토링
## 🚀 상세 설명
>1. 충전기 시설상세 객체에서, count 타입을 int -> long으로 수정
>2. 외부인 개방 여부관련 2가지 편 변수 AptInfoDetail DTO에 추가
>3. 아파트 상세조회시, 누락된 데이터는 타입에 따라 기본값을 반환하도록 코드 수정


> 스크린샷 순서
1. 정상 조회
2. 비어있는 데이터는 기본값으로 처리한 조회
3. 테이블에 데이터가 없을때, 500에러 반환
## 📸 스크린샷
![스크린샷 2025-02-13 232551](https://github.com/user-attachments/assets/a9241428-c5e1-4e67-9640-87dfd43f7b62)
![스크린샷 2025-02-13 231802](https://github.com/user-attachments/assets/5c4643ea-d6ec-40e2-bead-7cecc30ef04f)
![스크린샷 2025-02-13 232149](https://github.com/user-attachments/assets/52e520a7-8101-4c62-aba0-5652442c3394)

## 📢 노트