### PR TITLE
:recycle: Feat[#15]: 

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
@@ -1,12 +1,23 @@
 package com.myapt.domain.apt.dto;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
+
 import java.util.List;
 
+@JsonPropertyOrder({// JSON 출력 시, 아래의 명시된 순서대로 필드를 반환합니다.
+        "building",                // 건물 정보
+        "accessibleToPublic",      // 외부인 개방 여부 정보
+        "parking",                 // 주차 정보
+        "evCharging",              // 전기차 충전 정보
+        "disinfectionManagement",  // 소독 관리 정보
+        "securityManagement",      // 경비 관리 정보
+        "cleaningManagement",      // 청소 관리 정보
+        "generalManagement"        // 일반 관리 정보
+})
 // 아파트의 상세정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfoDetail(
     Building building, // 건물 정보
-    PropertyInfo propertyInfo, // 추가 정보
     AccessibleToPublic accessibleToPublic, // 외부인 개방 여부 정보
     Parking parking, // 주차 정보
     EvCharging evCharging, // 전기차 충전 정보
@@ -19,7 +30,6 @@ public record AptInfoDetail(
     @Builder
     public static AptInfoDetail of(
         long maxFloorCount, long basementFloorCount, long passengerCargoElevatorCount, String buildingStructure,
-        String approvalDate, String developer, String constructor, long numberOfUnits,
         boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic,
         long groundParkingSpaces, long undergroundParkingSpaces,
         long groundEvChargerCount, long undergroundEvChargerCount, long groundEvParkingSpaces,
@@ -31,7 +41,6 @@ public record AptInfoDetail(
     ) {
         return new AptInfoDetail(
             new Building(maxFloorCount, basementFloorCount, passengerCargoElevatorCount, buildingStructure),
-            new PropertyInfo(approvalDate, developer, constructor, numberOfUnits),
             new AccessibleToPublic(groundAccessibleToPublic, undergroundAccessibleToPublic),
             new Parking(groundParkingSpaces, undergroundParkingSpaces),
             new EvCharging(groundEvChargerCount, undergroundEvChargerCount, groundEvParkingSpaces, undergroundEvParkingSpaces, evChargingFacilitiesDetails),
@@ -44,9 +53,6 @@ public record AptInfoDetail(
 
     // 건물 정보를 나타내는 클래스입니다.
     public record Building(long maxFloorCount, long basementFloorCount, long passengerCargoElevatorCount, String buildingStructure) {}
-
-    // 추가 정보를 나타내는 클래스입니다.
-    public record PropertyInfo(String approvalDate, String developer, String constructor, long numberOfUnits) {}
 
     // 외부인 개방 여부 정보를 나타내는 클래스입니다.
     public record AccessibleToPublic(boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic) {}

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -161,10 +161,6 @@ public class AptServiceImpl implements AptService{
                 defaultIfNull(detailApts.getBasementFloorCount(), 0L),
                 defaultIfNull(detailApts.getPassengerCargoElevatorCount(), 0L),
                 defaultIfNull(detailApts.getBuildingStructure(), ""),
-                defaultIfNull(detailApts.getApprovalDate(), ""),
-                defaultIfNull(detailApts.getDeveloper(), ""),
-                defaultIfNull(detailApts.getConstructor(), ""),
-                defaultIfNull(detailApts.getNumberOfUnits(), 0L),
                 defaultIfNull(detailApts.getGroundAccessibleToPublic(), false), // 외부인 개방 여부(지상) 추가
                 defaultIfNull(detailApts.getUndergroundAccessibleToPublic(), false), // 외부인 개방 여부(지하) 추가
                 defaultIfNull(detailApts.getGroundParkingSpaces(), 0L),


### PR DESCRIPTION
… 추가하여 변수 순서를 지정

## 📌 이슈 번호
> #15
## 💬 리뷰 포인트
> 아파트 상세조회 API 구현 - 리펙토링
## 🚀 상세 설명
> 아파트 상세정보 조회시, 디자인이 확정된 데이터 순서에 맞게 값을 반환하도로 수정
1. JsonPropertyOrder 어노테이션을 AptInfoDetail DTO 에 추가하여, 프론트 반환시 데이터 순서 지정
2. 불필요한 propertyInfo 추가정보는 AptInfoDetail DTO 에서 삭제완료
## 📸 스크린샷
![스크린샷 2025-02-1
![스크린샷 2025-02-14 140453](https://github.com/user-attachments/assets/1fec083b-e02c-4952-8071-67f76b0a7c85)

![스크린샷 2025-02-14 140441](https://github.com/user-attachments/assets/dba8ed48-db45-41f4-84d3-5f7d4fc56efb)
4 140434](https://github.com/user-attachments/assets/d84b6b25-3f36-4261-a18e-00eee3068196)

## 📢 노트