### PR TITLE
:recycle: Feat[#11]: AptInfo DTO와 AptService의 getApartmentInfo 메소드를 수정

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
@@ -1,74 +1,60 @@
 package com.myapt.domain.apt.dto;
 
 import lombok.Builder;
+
 import java.util.List;
-import java.util.Map;
 
-@Builder
+// 아파트 기본 정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfo(
-        String detailId, // 아파트 상세 정보 ID
-        String name, // 아파트 명
-        String buildingType, // 건물 종류
-        String roadAddress, // 도로명 주소
-        String zipCode, // 우편 번호
-        String completionDate, // 준공일
-        String developer, // 시행사
-        String constructor, // 시공사
-        long numberOfUnits, // 세대수
-        // List<SalePriceInfo> salePrices, // 면적별 매매가
-        Map<String, Long> monthlyMaintenanceFees, // 월별 관리비
-        List<String> amenities, // 부대복리시설을 List로 변경
-        String buildingStructure, // 건물구조
-        String managementType, // 관리방식
-        String heatingType, // 난방방식
-        long cctvCount, // CCTV 대수(대)
-        long totalParkingSpaces, // 총주차 대수(대)
-        long totalGroundEvChargerCount, // 총 전기차 충전기 대수
-        String managementOfficeAddress, // 관리사무소 주소
-        String managementOfficeContact, // 관리사무소 연락처
-        String managementOfficeFax, // 관리사무소 팩스
-        String housingManager // 주택관리업자
+        AptBasicInfo aptInfo, // 아파트 기본 정보
+        BuildInfo buildInfo, // 건물 기본 정보
+        //List<SellingPrice> sellingPrice, // 매매가 정보
+        MonthlyMaintenanceFees monthlyMaintenanceFees, // 월별 관리비
+        EtcInfo etcInfo // 기타 정보
 ) {
+    // of 메서드는 인자를 받아 AptInfo 객체를 생성하는데, 이는 DTO 객체를 생성하여 클라이언트로 반환할 때 유용합니다.
     @Builder
-    public static record SalePriceInfo(long area, long price) {
-        // SalePriceInfo 레코드는 AptInfo의 속성 중 하나인 salePrices를 구성하는 요소입니다. 이 레코드는 각 아파트의 면적과 해당 면적의 매매가를 표현하기 위해 사용됩니다.
+    public static AptInfo of(
+            String detailId, String name, String roadAddress, String zipCode,
+            String completionDate, String developer, String constructor, long numberOfUnits,
+            //List<SellingPrice> sellingPrice,
+            String year, List<MonthlyMaintenanceData> monthlyMaintenanceData,
+            List<String> amenities, String buildingStructure, String managementType, String heatingType,
+            long cctvCount, long totalParkingSpaces, long totalGroundEvChargerCount,
+            String managementOfficeAddress, String managementOfficeContact, String managementOfficeFax,
+            String housingManager
+    ) {
+        return new AptInfo(
+                new AptBasicInfo(detailId, name, roadAddress, zipCode),
+                new BuildInfo(completionDate, developer, constructor, numberOfUnits),
+                //sellingPrice,
+                new MonthlyMaintenanceFees(year, monthlyMaintenanceData),
+                new EtcInfo(amenities, buildingStructure, managementType, heatingType, cctvCount, totalParkingSpaces,
+                        totalGroundEvChargerCount, managementOfficeAddress, managementOfficeContact,
+                        managementOfficeFax, housingManager)
+        );
     }
 
-    // of 메서드는 인자를 받아 ApartmentDetailInfo 객체를 생성하는데, 이는 DTO 객체를 생성하여 클라이언트로 반환할 때 유용합니다.
-    public static AptInfo of(
-            String detailId, String name, String buildingType, String roadAddress, String zipCode, String completionDate,
-            String developer, String constructor, long numberOfUnits,
-            // List<SalePriceInfo> salePrices,
-            Map<String, Long> monthlyMaintenanceFees,
-            List<String> amenities, // Map에서 List로 변경
-            String buildingStructure, String managementType, String heatingType, long cctvCount,
-            long totalParkingSpaces, long totalGroundEvChargerCount, // 총 전기차 충전기 대수 추가
-            String managementOfficeAddress, String managementOfficeContact,
-            String managementOfficeFax, String housingManager
-    ) {
-        return AptInfo.builder()
-                .detailId(detailId)
-                .name(name)
-                .buildingType(buildingType)
-                .roadAddress(roadAddress)
-                .zipCode(zipCode)
-                .completionDate(completionDate)
-                .developer(developer)
-                .constructor(constructor)
-                .numberOfUnits(numberOfUnits)
-                //.salePrices(salePrices)
-                .monthlyMaintenanceFees(monthlyMaintenanceFees)
-                .amenities(amenities) // List로 된 amenities를 사용
-                .buildingStructure(buildingStructure)
-                .managementType(managementType)
-                .heatingType(heatingType)
-                .cctvCount(cctvCount)
-                .totalParkingSpaces(totalParkingSpaces)
-                .totalGroundEvChargerCount(totalGroundEvChargerCount) // 총 전기차 충전기 대수 빌더에 추가
-                .managementOfficeAddress(managementOfficeAddress)
-                .managementOfficeContact(managementOfficeContact)
-                .managementOfficeFax(managementOfficeFax)
-                .housingManager(housingManager)
-                .build();
-    }
+    // 아파트 기본 정보를 나타내는 클래스입니다.
+    public record AptBasicInfo(String detailId, String name, String roadAddress, String zipCode) {}
+
+    // 건물 기본 정보를 나타내는 클래스입니다.
+    public record BuildInfo(String completionDate, String developer, String constructor, long numberOfUnits) {}
+
+    // 매매가 정보를 나타내는 클래스입니다.
+    //public record SellingPrice(long netArea, long price) {}
+
+    // 월별 관리비 정보를 나타내는 클래스입니다.
+    public record MonthlyMaintenanceFees(String year, List<MonthlyMaintenanceData> data) {}
+
+    // 월별 관리비 데이터 정보를 나타내는 클래스입니다.
+    public record MonthlyMaintenanceData(String month, long fee) {}
+
+    // 기타 정보를 나타내는 클래스입니다.
+    public record EtcInfo(
+            List<String> amenities, String buildingStructure, String managementType, String heatingType,
+            long cctvCount, long totalParkingSpaces, long totalGroundEvChargerCount,
+            String managementOfficeAddress, String managementOfficeContact, String managementOfficeFax,
+            String housingManager
+    ) {}
 }

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -91,64 +91,82 @@ public class AptServiceImpl implements AptService{
 
     @Override
     public AptInfo getApartmentInfo(String aptsId) {
-        // #1. apts_id 를 사용해서, Apts 와 DetailApts의 리포지토리들로 부터 아파트 기본정보들을 받아온다.
+        // #1. apts_id를 사용해서, Apts와 DetailApts의 리포지토리들로부터 아파트 기본 정보를 받아온다.
         Apts apts = aptRepository.findById(aptsId).orElseThrow(() -> new RuntimeException("아파트 기본정보 데이터를 조회할 수 없습니다."));
         DetailApts detailApts = detailAptsRepository.findByApts_Id(aptsId).orElseThrow(() -> new RuntimeException("아파트 상세정보 데이터를 조회할 수 없습니다."));
 
-        // #2. detail_apts_id(아파트 관리비코드)에 해당하는 월별 관리비를 계산 및 나머지 요소들과 함께 아파트기본정보를 반환하는 코드
+        // #2. detail_apts_id(아파트 관리비 코드)에 해당하는 월별 관리비를 계산 및 나머지 요소들과 함께 아파트 기본정보를 반환하는 코드
         List<MngCost> mngCosts = defaultIfNull(mngCostRepository.findByDetailAptsId(detailApts.getId()), Collections.emptyList());
 
         // #3. 세대수 가져오기
         long numberOfUnits = defaultIfNull(apts.getNmhsh(), 0).longValue();
 
         // #4. 월별 관리비 계산 (세대수 이용)
-        Map<String, Long> monthlyMaintenanceFees = mngCosts.stream()
-                .collect(Collectors.toMap(
-                        mngCost -> String.valueOf(defaultIfNull(mngCost.getOccurrenceYearMonth(), 0)),
-                        mngCost -> {
-                            long individualUsageSumPerUnit = defaultIfNull(mngCost.getIndividualUsageSum(), 0L) / numberOfUnits;
-                            long reserveFundMonthlyChargePerUnit = defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) / numberOfUnits;
-                            long totalCommonManagementFeeSumPerUnit = defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) / numberOfUnits;
+        List<AptInfo.MonthlyMaintenanceData> monthlyMaintenanceData = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
 
-                            return individualUsageSumPerUnit + reserveFundMonthlyChargePerUnit + totalCommonManagementFeeSumPerUnit;
-                        }
-                ));
+                    long fee = (defaultIfNull(mngCost.getIndividualUsageSum(), 0L) / numberOfUnits) +
+                            (defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) / numberOfUnits) +
+                            (defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) / numberOfUnits);
 
-        // #5. amenities 문자열을 List<String>으로 변환
+                    return new AptInfo.MonthlyMaintenanceData(month, fee);
+                })
+                .collect(Collectors.toList());
+        // #4-2. 월별 관리비 데이터를 월(month) 기준으로 정렬
+        monthlyMaintenanceData.sort(Comparator.comparing(AptInfo.MonthlyMaintenanceData::month));
+
+        // #5. 연도 정보 추출 (첫 번째 관리비 기록의 연도 사용)
+        String year = mngCosts.stream()
+                .findFirst()
+                .map(mngCost -> String.valueOf(mngCost.getOccurrenceYearMonth()).substring(0, 4))
+                .orElse("연도 정보 없음");
+
+        // #6. amenities 문자열을 List<String>으로 변환
         List<String> amenitiesList = Arrays.stream(defaultIfNull(detailApts.getAmenities(), "").split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
 
-        // #6. 총 전기차 충전기 대수 계산
+        // #7. 총 전기차 충전기 대수 계산
         long totalGroundEvChargerCount = defaultIfNull(detailApts.getGroundEvChargerCount(), 0).longValue() +
                 defaultIfNull(detailApts.getUndergroundEvChargerCount(), 0).longValue();
 
-        // #7. AptInfo DTO 객체를 생성해서 모든 정보를 담는다.
+        // #8. 매매가 정보를 가져와서 SellingPrice 객체 리스트로 변환
+//        List<AptInfo.SellingPrice> sellingPrices = Optional.ofNullable(detailApts.getSellingPrice())
+//                .orElse(Collections.emptyList())
+//                .stream()
+//                .map(sp -> new AptInfo.SellingPrice(sp.getNetArea(), sp.getPrice()))
+//                .collect(Collectors.toList());
+
+        // #9. AptInfo DTO 객체를 생성해서 모든 정보를 담는다.
         return AptInfo.of(
                 defaultIfNull(detailApts.getId(), ""),
                 defaultIfNull(apts.getAptNm(), ""),
-                defaultIfNull(detailApts.getComplexType(), ""),
                 defaultIfNull(apts.getRdnmadr(), ""),
                 defaultIfNull(detailApts.getPostalCode(), ""),
                 defaultIfNull(String.valueOf(apts.getUseAprvYear()), "0"),
                 defaultIfNull(detailApts.getDeveloper(), ""),
                 defaultIfNull(detailApts.getConstructor(), ""),
                 numberOfUnits,
-                monthlyMaintenanceFees,
-                amenitiesList, // List<String>으로 전달
+                //sellingPrices, // 매매가 정보 추가
+                year, // 연도 정보 추가
+                monthlyMaintenanceData,
+                amenitiesList,
                 defaultIfNull(apts.getBuldStru(), ""),
                 defaultIfNull(detailApts.getManagementType(), ""),
                 defaultIfNull(detailApts.getHeatingType(), ""),
                 defaultIfNull(detailApts.getCctvCount(), 0).longValue(),
                 defaultIfNull(detailApts.getTotalParkingSpaces(), 0).longValue(),
-                totalGroundEvChargerCount, // 총 전기차 충전기 대수 설정
+                totalGroundEvChargerCount,
                 defaultIfNull(detailApts.getManagementOfficeAddress(), ""),
                 defaultIfNull(detailApts.getManagementOfficeContact(), ""),
                 defaultIfNull(detailApts.getManagementOfficeFax(), ""),
                 defaultIfNull(detailApts.getHousingManager(), "")
         );
     }
+
 
     @Override
     public AptInfoDetail getApartmentInfoDetail(String detailAptsId) {


### PR DESCRIPTION
## 📌 이슈 번호
> #11 
## 💬 리뷰 포인트
> 아파트 기본 정보 조회 API - 리펙토링
## 🚀 상세 설명
> API 명세서에 따라서, 반환되는 데이터 순서 수정
## 📸 스크린샷
![기본정보조회1](https://github.com/user-attachments/assets/4fbaf412-7583-4f3b-9742-e1c1c47edd18)
![기본정보조회2](https://github.com/user-attachments/assets/1333d47b-19c1-48bb-b41c-5365a44cc76b)
![기본정보조회 - 비어있는 부분들 기본값 반환](https://github.com/user-attachments/assets/7509b51c-3db3-4580-9a24-013954d85e2b)


## 📢 노트