### PR TITLE
#17

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 // 아파트 기본 정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfo(
         AptBasicInfo aptInfo, // 아파트 기본 정보

--- a/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
@@ -3,84 +3,19 @@ package com.myapt.domain.apt.dto;
 import lombok.Builder;
 
 import java.util.List;
-import java.util.Map;
 
 @Builder
 public record MngCostInfo(
-        // 공용관리비 상세 내역
-        List<MonthlyCommonManagementFee> monthlyTotalCommonManagementFeeSum,
-
-        // 개별사용료 상세 내역
-        List<MonthlyIndividualManagementFee> monthlyTotalIndividualManagementFeeSum,
-
-        // 장충금 월부과액 상세 내역
-        Map<Long, Long> reserveFundMonthlyCharge,
-
-        // 장충금 월사용액 상세 내역
-        Map<Long, Long> reserveFundMonthlyExpenditure,
-
-        // 장충금 총적립금액 상세 내역
-        Map<Long, Long> reserveFundTotalAccumulated,
-
-        // 장충금 적립율 상세 내역
-        Map<Long, Long> reserveFundAccumulationRate,
-
-        // 잡수입 월수입금액 상세 내역
-        List<MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmount
+        String year,                                 // 연도
+        List<MonthlyFee> individualUsageSum,         // 개별사용료 상세 내역
+        List<MonthlyFee> totalCommonManagementFeeSum,// 공용관리비 월별 데이터
+        List<MonthlyFee> reserveFundMonthlyCharge    // 장충금 월 부과액
 ) {
 
     @Builder
-    public static record MonthlyCommonManagementFee(
-            long occurrenceYearMonth, // 월
-            long laborCost, // 인건비
-            long officeExpenses, // 제사무비
-            long taxesAndDues, // 제세공과금
-            long clothingCost, // 피복비
-            long trainingCost, // 교육훈련비
-            long vehicleMaintenanceCost, // 차량유지비
-            long otherIncidentalExpenses, // 그 밖의 부대비용
-            long cleaningCost, // 청소비
-            long securityCost, // 경비비
-            long disinfectionCost, // 소독비
-            long elevatorMaintenanceCost, // 승강기 유지비
-            long intelligentNetworkMaintenance, // 지능형 네트워크 유지비
-            long repairCost, // 수선비
-            long facilityMaintenanceCost, // 시설유지비
-            long safetyInspectionCost, // 안전 점검비
-            long disasterPreventionCost, // 재해예방비
-            long managementCommissionFee // 위탁관리 수수료
-    ) {
-    }
-
-    @Builder
-    public static record MonthlyIndividualManagementFee(
-            long occurrenceYearMonth, // 월
-            long heatingCostCommon, // 난방비(공용)
-            long heatingCostIndividual, // 난방비(전용)
-            long hotWaterCostCommon, // 급탕비(공용)
-            long hotWaterCostIndividual, // 급탕비(전용)
-            long gasUsageCostCommon, // 가스사용료(공용)
-            long gasUsageCostIndividual, // 가스사용료(전용)
-            long electricityCostCommon, // 전기료(공용)
-            long electricityCostIndividual, // 전기료(전용)
-            long waterCostCommon, // 수도료(공용)
-            long waterCostIndividual, // 수도료(전용)
-            long tvFee, // TV 수신료
-            long sewageFee, // 정화조 오물 수수료
-            long wasteFee, // 생활폐기물 수수료
-            long associationCost, // 입대의 운영비
-            long buildingInsuranceFee, // 건물 보험료
-            long electionCost, // 선관위 운영비
-            long etcFee // 기타
-    ) {
-    }
-
-    @Builder
-    public static record MiscellaneousIncomeMonthlyAmount(
-            long occurrenceYearMonth, // 월
-            long miscellaneousIncomeMonthlyAmount, // 잡수입 월수입금액
-            long residentContributionRevenue, // 입주자 기여수익
-            long commonContributionRevenue // 공동 기여수익
+    public static record MonthlyFee(
+            String month, // 월
+            long fee      // 비용
     ) {
     }
 }

--- a/src/main/java/com/myapt/domain/apt/entity/MngCost.java
+++ b/src/main/java/com/myapt/domain/apt/entity/MngCost.java
@@ -33,7 +33,7 @@ public class MngCost {
     private String complexName; // 단지명
 
     @Column(name = "OccurrenceYearMonth")
-    private Long occurrenceYearMonth; // 발생 연월
+    private String occurrenceYearMonth; // 발생 연월
 
     @Column(name = "IndividualUsageSum")
     private Long individualUsageSum; // 개별 사용 합계

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -212,140 +212,6 @@ public class AptServiceImpl implements AptService{
         return value != null ? value : defaultValue;
     }
 
-    @Override
-    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
-        // #1. detailAptsId를 사용하여 MngCost 리포지토리로부터 해당 아파트 관리비 상세정보들을 받아온다.
-        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
-
-        // #2-2 월별 공용관리비 상세 내역을 리스트로 변환
-        List<MngCostInfo.MonthlyCommonManagementFee> monthlyCommonManagementFeeList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MonthlyCommonManagementFee(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getLaborCost(), 0L),
-                        defaultIfNull(mngCost.getOfficeExpenses(), 0L),
-                        defaultIfNull(mngCost.getTaxesAndDues(), 0L),
-                        defaultIfNull(mngCost.getClothingCost(), 0L),
-                        defaultIfNull(mngCost.getTrainingCost(), 0L),
-                        defaultIfNull(mngCost.getVehicleMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getOtherIncidentalExpenses(), 0L),
-                        defaultIfNull(mngCost.getCleaningCost(), 0L),
-                        defaultIfNull(mngCost.getSecurityCost(), 0L),
-                        defaultIfNull(mngCost.getDisinfectionCost(), 0L),
-                        defaultIfNull(mngCost.getElevatorMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getIntelligentNetworkMaintenance(), 0L),
-                        defaultIfNull(mngCost.getRepairCost(), 0L),
-                        defaultIfNull(mngCost.getFacilityMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getSafetyInspectionCost(), 0L),
-                        defaultIfNull(mngCost.getDisasterPreventionCost(), 0L),
-                        defaultIfNull(mngCost.getManagementCommissionFee(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MonthlyCommonManagementFee::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-3 월별 개별관리비 상세 내역을 리스트로 변환
-        List<MngCostInfo.MonthlyIndividualManagementFee> monthlyIndividualManagementFeeList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MonthlyIndividualManagementFee(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getHeatingCostCommon(), 0L),
-                        defaultIfNull(mngCost.getHeatingCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getHotWaterCostCommon(), 0L),
-                        defaultIfNull(mngCost.getHotWaterCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getGasUsageCostCommon(), 0L),
-                        defaultIfNull(mngCost.getGasUsageCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getElectricityCostCommon(), 0L),
-                        defaultIfNull(mngCost.getElectricityCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getWaterCostCommon(), 0L),
-                        defaultIfNull(mngCost.getWaterCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getTvFee(), 0L),
-                        defaultIfNull(mngCost.getSewageFee(), 0L),
-                        defaultIfNull(mngCost.getWasteFee(), 0L),
-                        defaultIfNull(mngCost.getAssociationCost(), 0L),
-                        defaultIfNull(mngCost.getBuildingInsuranceFee(), 0L),
-                        defaultIfNull(mngCost.getElectionCost(), 0L),
-                        defaultIfNull(mngCost.getEtc(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MonthlyIndividualManagementFee::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-4 월별 잡수입 상세 내역을 리스트로 변환
-        List<MngCostInfo.MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmountList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MiscellaneousIncomeMonthlyAmount(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getMiscellaneousIncomeMonthlyAmount(), 0L),
-                        defaultIfNull(mngCost.getResidentContributionRevenue(), 0L),
-                        defaultIfNull(mngCost.getCommonContributionRevenue(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MiscellaneousIncomeMonthlyAmount::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-5 장충금 월부과액 상세 내역을 Map으로 변환 (월별 부과액)
-        Map<Long, Long> reserveFundMonthlyCharge = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-6 장충금 월사용액 상세 내역을 Map으로 변환 (월별 사용액)
-        Map<Long, Long> reserveFundMonthlyExpenditure = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundMonthlyExpenditure(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-7 장충금 총적립금액 상세 내역을 Map으로 변환 (월별 총적립액)
-        Map<Long, Long> reserveFundTotalAccumulated = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundTotalAccumulated(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-8 장충금 적립율 상세 내역을 Map으로 변환 (월별 적립률)
-        Map<Long, Long> reserveFundAccumulationRate = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundAccumulationRate(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #3. MngCostInfo DTO를 빌드하여 모든 정보를 담아 반환
-        return MngCostInfo.builder()
-                .monthlyTotalCommonManagementFeeSum(monthlyCommonManagementFeeList) // 공용관리비 상세
-                .monthlyTotalIndividualManagementFeeSum(monthlyIndividualManagementFeeList) // 개별관리비 상세
-                .reserveFundMonthlyCharge(reserveFundMonthlyCharge) // 장충금 월부과액
-                .reserveFundMonthlyExpenditure(reserveFundMonthlyExpenditure) // 장충금 월사용액
-                .reserveFundTotalAccumulated(reserveFundTotalAccumulated) // 장충금 총적립금액
-                .reserveFundAccumulationRate(reserveFundAccumulationRate) // 장충금 적립율
-                .miscellaneousIncomeMonthlyAmount(miscellaneousIncomeMonthlyAmountList) // 잡수입 월수입금액
-                .build();
-    }
-
-
-
     // evChargingFacilitiesDetails 의 문자열을 파싱하는 함수
     public static List<AptInfoDetail.EvChargingFacilityDetail> parseEvChargingDetails(String data) {
         List<AptInfoDetail.EvChargingFacilityDetail> details = new ArrayList<>();
@@ -365,7 +231,7 @@ public class AptServiceImpl implements AptService{
                     String provider = parts[5]; // 공급자
                     // 객체 생성
                     AptInfoDetail.EvChargingFacilityDetail detail = new AptInfoDetail.EvChargingFacilityDetail(
-                        location, type, connector, chargingSpeed, count, provider);
+                            location, type, connector, chargingSpeed, count, provider);
                     // 리스트에 추가
                     details.add(detail);
                 } catch (NumberFormatException e) {
@@ -379,4 +245,60 @@ public class AptServiceImpl implements AptService{
         }
         return details;
     }
+    @Override // 관리비 상세조회 API
+    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
+        // 지정된 아파트 ID에 대한 세부 정보를 가져옵니다.
+        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
+
+        // 첫 번째 레코드의 occurrenceYearMonth에서 연도를 추출합니다.
+        String year = mngCosts.isEmpty() ? "0000" : mngCosts.get(0).getOccurrenceYearMonth().substring(0, 4);
+
+        // 개별 사용료를 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> individualUsageSum = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getIndividualUsageSum(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // 공용 관리비를 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> totalCommonManagementFeeSum = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // 장충금 월 부과액을 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> reserveFundMonthlyCharge = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // MngCostInfo DTO를 빌드하고 반환합니다.
+        return MngCostInfo.builder()
+                .year(year) // 연도 추가
+                .individualUsageSum(individualUsageSum)
+                .totalCommonManagementFeeSum(totalCommonManagementFeeSum)
+                .reserveFundMonthlyCharge(reserveFundMonthlyCharge)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #17 
## 💬 리뷰 포인트
> 변경된 관리비 상세조회 API 리펙토링
## 🚀 상세 설명
1. [연도, 개별사용료 합계, 공용관리비 합계, 장충금 월부과액] 만 반환함
2. MngCost Entity의 occurrenceYearMonth(발생연월) 변수가 Long 타입에서 -> String으로 수정됨
## 📸 스크린샷
![스크린샷 2025-02-14 214242](https://github.com/user-attachments/assets/dadcc6bf-9f6d-474d-b92e-52de3c4c162a)
![스크린샷 2025-02-14 214253](https://github.com/user-attachments/assets/382f44df-7fe7-4c5f-980d-ddd6542233d4)
![스크린샷 2025-02-14 214259](https://github.com/user-attachments/assets/a6810190-356e-4421-8fdc-2e8c3dfb0c2b)

## 📢 노트
