### PR TITLE
Feat/apt #17

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/AptController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/AptController.java
@@ -126,7 +126,9 @@ public class AptController {
     // 		@ApiResponse(responseCode = "500", description = "서버 오류")
     // 	}
     // )
-    public ResTemplate<MngCostInfo> getMngCostInfo(@RequestParam String id) { //아파트 관리비 코드(기본키)로 조회
+
+    // 아파트 관리비 코드(기본키) + 아파트
+    public ResTemplate<MngCostInfo> getMngCostInfo(@RequestParam String id) {
         MngCostInfo mngCostInfo = aptService.getMngCostInfoDetail(id);
         return new ResTemplate<>(HttpStatus.OK, "관리비 상세 정보 조회 성공", mngCostInfo);
     }

--- a/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 import java.util.List;
 
+@Builder
 // 아파트 기본 정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfo(
         AptBasicInfo aptInfo, // 아파트 기본 정보

--- a/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
@@ -3,84 +3,19 @@ package com.myapt.domain.apt.dto;
 import lombok.Builder;
 
 import java.util.List;
-import java.util.Map;
 
 @Builder
 public record MngCostInfo(
-        // 공용관리비 상세 내역
-        List<MonthlyCommonManagementFee> monthlyTotalCommonManagementFeeSum,
-
-        // 개별사용료 상세 내역
-        List<MonthlyIndividualManagementFee> monthlyTotalIndividualManagementFeeSum,
-
-        // 장충금 월부과액 상세 내역
-        Map<Long, Long> reserveFundMonthlyCharge,
-
-        // 장충금 월사용액 상세 내역
-        Map<Long, Long> reserveFundMonthlyExpenditure,
-
-        // 장충금 총적립금액 상세 내역
-        Map<Long, Long> reserveFundTotalAccumulated,
-
-        // 장충금 적립율 상세 내역
-        Map<Long, Long> reserveFundAccumulationRate,
-
-        // 잡수입 월수입금액 상세 내역
-        List<MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmount
+        String year,                                 // 연도
+        List<MonthlyFee> individualUsageSum,         // 개별사용료 상세 내역
+        List<MonthlyFee> totalCommonManagementFeeSum,// 공용관리비 월별 데이터
+        List<MonthlyFee> reserveFundMonthlyCharge    // 장충금 월 부과액
 ) {
 
     @Builder
-    public static record MonthlyCommonManagementFee(
-            long occurrenceYearMonth, // 월
-            long laborCost, // 인건비
-            long officeExpenses, // 제사무비
-            long taxesAndDues, // 제세공과금
-            long clothingCost, // 피복비
-            long trainingCost, // 교육훈련비
-            long vehicleMaintenanceCost, // 차량유지비
-            long otherIncidentalExpenses, // 그 밖의 부대비용
-            long cleaningCost, // 청소비
-            long securityCost, // 경비비
-            long disinfectionCost, // 소독비
-            long elevatorMaintenanceCost, // 승강기 유지비
-            long intelligentNetworkMaintenance, // 지능형 네트워크 유지비
-            long repairCost, // 수선비
-            long facilityMaintenanceCost, // 시설유지비
-            long safetyInspectionCost, // 안전 점검비
-            long disasterPreventionCost, // 재해예방비
-            long managementCommissionFee // 위탁관리 수수료
-    ) {
-    }
-
-    @Builder
-    public static record MonthlyIndividualManagementFee(
-            long occurrenceYearMonth, // 월
-            long heatingCostCommon, // 난방비(공용)
-            long heatingCostIndividual, // 난방비(전용)
-            long hotWaterCostCommon, // 급탕비(공용)
-            long hotWaterCostIndividual, // 급탕비(전용)
-            long gasUsageCostCommon, // 가스사용료(공용)
-            long gasUsageCostIndividual, // 가스사용료(전용)
-            long electricityCostCommon, // 전기료(공용)
-            long electricityCostIndividual, // 전기료(전용)
-            long waterCostCommon, // 수도료(공용)
-            long waterCostIndividual, // 수도료(전용)
-            long tvFee, // TV 수신료
-            long sewageFee, // 정화조 오물 수수료
-            long wasteFee, // 생활폐기물 수수료
-            long associationCost, // 입대의 운영비
-            long buildingInsuranceFee, // 건물 보험료
-            long electionCost, // 선관위 운영비
-            long etcFee // 기타
-    ) {
-    }
-
-    @Builder
-    public static record MiscellaneousIncomeMonthlyAmount(
-            long occurrenceYearMonth, // 월
-            long miscellaneousIncomeMonthlyAmount, // 잡수입 월수입금액
-            long residentContributionRevenue, // 입주자 기여수익
-            long commonContributionRevenue // 공동 기여수익
+    public static record MonthlyFee(
+            String month, // 월
+            long fee      // 비용
     ) {
     }
 }

--- a/src/main/java/com/myapt/domain/apt/entity/MngCost.java
+++ b/src/main/java/com/myapt/domain/apt/entity/MngCost.java
@@ -33,7 +33,7 @@ public class MngCost {
     private String complexName; // 단지명
 
     @Column(name = "OccurrenceYearMonth")
-    private Long occurrenceYearMonth; // 발생 연월
+    private String occurrenceYearMonth; // 발생 연월
 
     @Column(name = "IndividualUsageSum")
     private Long individualUsageSum; // 개별 사용 합계

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -170,7 +170,7 @@ public class AptServiceImpl implements AptService{
 
     @Override
     public AptInfoDetail getApartmentInfoDetail(String detailAptsId) {
-        // #1. apts_id 를 사용해서 DetailApts의 리포지토리로부터 아파트 상세정보들을 받아온다.
+        // #1. detailAptsId 를 사용해서 DetailApts의 리포지토리로부터 아파트 상세정보들을 받아온다.
         DetailApts detailApts = detailAptsRepository.findById(detailAptsId)
                 .orElseThrow(() -> new RuntimeException("해당 아파트 상세정보가 서버에 존재하지 않습니다."));
 
@@ -247,52 +247,63 @@ public class AptServiceImpl implements AptService{
     }
     @Override // 관리비 상세조회 API
     public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
-        // 지정된 아파트 ID에 대한 세부 정보를 가져옵니다.
+
+        // #1. 지정된 아파트 ID에 대한 아파트 상세정보를 가져옵니다.
+        DetailApts detailApts = detailAptsRepository.findById(detailAptsId)
+                .orElseThrow(() -> new RuntimeException("해당 아파트 상세정보가 서버에 존재하지 않습니다."));
+
+        // #1-2. 세대수 가져오기
+        long numberOfUnits = defaultIfNull(detailApts.getNumberOfUnits(), 0).longValue();
+
+        // #2. 지정된 아파트 ID에 대한 관리비 세부 정보를 가져옵니다.
         List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
 
-        // 첫 번째 레코드의 occurrenceYearMonth에서 연도를 추출합니다.
+        // #2-2. 첫 번째 레코드의 occurrenceYearMonth에서 연도를 추출합니다.
         String year = mngCosts.isEmpty() ? "0000" : mngCosts.get(0).getOccurrenceYearMonth().substring(0, 4);
 
-        // 개별 사용료를 변환하고 월 기준으로 정렬합니다.
+        // #2-3. 개별 사용료를 변환하고 월 기준으로 정렬합니다.
         List<MngCostInfo.MonthlyFee> individualUsageSum = mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
+                    long individualUsage = defaultIfNull(mngCost.getIndividualUsageSum(), 0L);
                     return new MngCostInfo.MonthlyFee(
                             month,
-                            defaultIfNull(mngCost.getIndividualUsageSum(), 0L) // 직접 값을 가져옵니다.
+                            numberOfUnits > 0 ? individualUsage / numberOfUnits : 0L
                     );
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
 
-        // 공용 관리비를 변환하고 월 기준으로 정렬합니다.
+        // #2-4. 공용 관리비를 변환하고 월 기준으로 정렬합니다.
         List<MngCostInfo.MonthlyFee> totalCommonManagementFeeSum = mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
+                    long commonFee = defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L);
                     return new MngCostInfo.MonthlyFee(
                             month,
-                            defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) // 직접 값을 가져옵니다.
+                            numberOfUnits > 0 ? commonFee / numberOfUnits : 0L
                     );
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
 
-        // 장충금 월 부과액을 변환하고 월 기준으로 정렬합니다.
+        // #2-5. 장충금 월 부과액을 변환하고 월 기준으로 정렬합니다.
         List<MngCostInfo.MonthlyFee> reserveFundMonthlyCharge = mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
+                    long reserveFund = defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L);
                     return new MngCostInfo.MonthlyFee(
                             month,
-                            defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) // 직접 값을 가져옵니다.
+                            numberOfUnits > 0 ? reserveFund / numberOfUnits : 0L
                     );
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
 
-        // MngCostInfo DTO를 빌드하고 반환합니다.
+        // #3. MngCostInfo DTO를 빌드하고 반환합니다.
         return MngCostInfo.builder()
                 .year(year) // 연도 추가
                 .individualUsageSum(individualUsageSum)
@@ -300,5 +311,4 @@ public class AptServiceImpl implements AptService{
                 .reserveFundMonthlyCharge(reserveFundMonthlyCharge)
                 .build();
     }
-
 }

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -212,140 +212,6 @@ public class AptServiceImpl implements AptService{
         return value != null ? value : defaultValue;
     }
 
-    @Override
-    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
-        // #1. detailAptsId를 사용하여 MngCost 리포지토리로부터 해당 아파트 관리비 상세정보들을 받아온다.
-        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
-
-        // #2-2 월별 공용관리비 상세 내역을 리스트로 변환
-        List<MngCostInfo.MonthlyCommonManagementFee> monthlyCommonManagementFeeList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MonthlyCommonManagementFee(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getLaborCost(), 0L),
-                        defaultIfNull(mngCost.getOfficeExpenses(), 0L),
-                        defaultIfNull(mngCost.getTaxesAndDues(), 0L),
-                        defaultIfNull(mngCost.getClothingCost(), 0L),
-                        defaultIfNull(mngCost.getTrainingCost(), 0L),
-                        defaultIfNull(mngCost.getVehicleMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getOtherIncidentalExpenses(), 0L),
-                        defaultIfNull(mngCost.getCleaningCost(), 0L),
-                        defaultIfNull(mngCost.getSecurityCost(), 0L),
-                        defaultIfNull(mngCost.getDisinfectionCost(), 0L),
-                        defaultIfNull(mngCost.getElevatorMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getIntelligentNetworkMaintenance(), 0L),
-                        defaultIfNull(mngCost.getRepairCost(), 0L),
-                        defaultIfNull(mngCost.getFacilityMaintenanceCost(), 0L),
-                        defaultIfNull(mngCost.getSafetyInspectionCost(), 0L),
-                        defaultIfNull(mngCost.getDisasterPreventionCost(), 0L),
-                        defaultIfNull(mngCost.getManagementCommissionFee(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MonthlyCommonManagementFee::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-3 월별 개별관리비 상세 내역을 리스트로 변환
-        List<MngCostInfo.MonthlyIndividualManagementFee> monthlyIndividualManagementFeeList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MonthlyIndividualManagementFee(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getHeatingCostCommon(), 0L),
-                        defaultIfNull(mngCost.getHeatingCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getHotWaterCostCommon(), 0L),
-                        defaultIfNull(mngCost.getHotWaterCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getGasUsageCostCommon(), 0L),
-                        defaultIfNull(mngCost.getGasUsageCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getElectricityCostCommon(), 0L),
-                        defaultIfNull(mngCost.getElectricityCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getWaterCostCommon(), 0L),
-                        defaultIfNull(mngCost.getWaterCostIndividual(), 0L),
-                        defaultIfNull(mngCost.getTvFee(), 0L),
-                        defaultIfNull(mngCost.getSewageFee(), 0L),
-                        defaultIfNull(mngCost.getWasteFee(), 0L),
-                        defaultIfNull(mngCost.getAssociationCost(), 0L),
-                        defaultIfNull(mngCost.getBuildingInsuranceFee(), 0L),
-                        defaultIfNull(mngCost.getElectionCost(), 0L),
-                        defaultIfNull(mngCost.getEtc(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MonthlyIndividualManagementFee::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-4 월별 잡수입 상세 내역을 리스트로 변환
-        List<MngCostInfo.MiscellaneousIncomeMonthlyAmount> miscellaneousIncomeMonthlyAmountList = mngCosts.stream()
-                .map(mngCost -> new MngCostInfo.MiscellaneousIncomeMonthlyAmount(
-                        defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        defaultIfNull(mngCost.getMiscellaneousIncomeMonthlyAmount(), 0L),
-                        defaultIfNull(mngCost.getResidentContributionRevenue(), 0L),
-                        defaultIfNull(mngCost.getCommonContributionRevenue(), 0L)
-                ))
-                .sorted(Comparator.comparing(
-                        MngCostInfo.MiscellaneousIncomeMonthlyAmount::occurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toList());
-
-        // #2-5 장충금 월부과액 상세 내역을 Map으로 변환 (월별 부과액)
-        Map<Long, Long> reserveFundMonthlyCharge = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-6 장충금 월사용액 상세 내역을 Map으로 변환 (월별 사용액)
-        Map<Long, Long> reserveFundMonthlyExpenditure = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundMonthlyExpenditure(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-7 장충금 총적립금액 상세 내역을 Map으로 변환 (월별 총적립액)
-        Map<Long, Long> reserveFundTotalAccumulated = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundTotalAccumulated(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #2-8 장충금 적립율 상세 내역을 Map으로 변환 (월별 적립률)
-        Map<Long, Long> reserveFundAccumulationRate = mngCosts.stream()
-                .sorted(Comparator.comparing(
-                        MngCost::getOccurrenceYearMonth,
-                        Comparator.nullsLast(Long::compareTo))) // null을 마지막에 배치
-                .collect(Collectors.toMap(
-                        mngCost -> defaultIfNull(mngCost.getOccurrenceYearMonth(), 0L),
-                        mngCost -> defaultIfNull(mngCost.getReserveFundAccumulationRate(), 0L),
-                        (oldValue, newValue) -> oldValue,
-                        LinkedHashMap::new
-                ));
-
-        // #3. MngCostInfo DTO를 빌드하여 모든 정보를 담아 반환
-        return MngCostInfo.builder()
-                .monthlyTotalCommonManagementFeeSum(monthlyCommonManagementFeeList) // 공용관리비 상세
-                .monthlyTotalIndividualManagementFeeSum(monthlyIndividualManagementFeeList) // 개별관리비 상세
-                .reserveFundMonthlyCharge(reserveFundMonthlyCharge) // 장충금 월부과액
-                .reserveFundMonthlyExpenditure(reserveFundMonthlyExpenditure) // 장충금 월사용액
-                .reserveFundTotalAccumulated(reserveFundTotalAccumulated) // 장충금 총적립금액
-                .reserveFundAccumulationRate(reserveFundAccumulationRate) // 장충금 적립율
-                .miscellaneousIncomeMonthlyAmount(miscellaneousIncomeMonthlyAmountList) // 잡수입 월수입금액
-                .build();
-    }
-
-
-
     // evChargingFacilitiesDetails 의 문자열을 파싱하는 함수
     public static List<AptInfoDetail.EvChargingFacilityDetail> parseEvChargingDetails(String data) {
         List<AptInfoDetail.EvChargingFacilityDetail> details = new ArrayList<>();
@@ -365,7 +231,7 @@ public class AptServiceImpl implements AptService{
                     String provider = parts[5]; // 공급자
                     // 객체 생성
                     AptInfoDetail.EvChargingFacilityDetail detail = new AptInfoDetail.EvChargingFacilityDetail(
-                        location, type, connector, chargingSpeed, count, provider);
+                            location, type, connector, chargingSpeed, count, provider);
                     // 리스트에 추가
                     details.add(detail);
                 } catch (NumberFormatException e) {
@@ -379,4 +245,60 @@ public class AptServiceImpl implements AptService{
         }
         return details;
     }
+    @Override // 관리비 상세조회 API
+    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
+        // 지정된 아파트 ID에 대한 세부 정보를 가져옵니다.
+        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
+
+        // 첫 번째 레코드의 occurrenceYearMonth에서 연도를 추출합니다.
+        String year = mngCosts.isEmpty() ? "0000" : mngCosts.get(0).getOccurrenceYearMonth().substring(0, 4);
+
+        // 개별 사용료를 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> individualUsageSum = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getIndividualUsageSum(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // 공용 관리비를 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> totalCommonManagementFeeSum = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // 장충금 월 부과액을 변환하고 월 기준으로 정렬합니다.
+        List<MngCostInfo.MonthlyFee> reserveFundMonthlyCharge = mngCosts.stream()
+                .map(mngCost -> {
+                    String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
+                    String month = occurrenceYearMonth.substring(4, 6);
+                    return new MngCostInfo.MonthlyFee(
+                            month,
+                            defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) // 직접 값을 가져옵니다.
+                    );
+                })
+                .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
+                .collect(Collectors.toList());
+
+        // MngCostInfo DTO를 빌드하고 반환합니다.
+        return MngCostInfo.builder()
+                .year(year) // 연도 추가
+                .individualUsageSum(individualUsageSum)
+                .totalCommonManagementFeeSum(totalCommonManagementFeeSum)
+                .reserveFundMonthlyCharge(reserveFundMonthlyCharge)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
>  #17 
## 💬 리뷰 포인트
> 관리비 상세조회 API - 리펙토링
## 🚀 상세 설명
1. [연도, 개별사용료 합계/세대수, 공용관리비 합계/세대수, 장충금 월부과액/세대수] 만 반환함 -> 한 세대 당 관리비가 나옴
2. 세대수는 DetailApts 엔티티의 세대수(number_of_units) 변수 값으로 지정
3. MngCost Entity의 occurrenceYearMonth(발생연월) 변수가 Long 타입에서 -> String으로 수정됨
## 📸 스크린샷
![스크린샷 2025-02-14 221859](https://github.com/user-attachments/assets/7bcbb445-2041-466b-927c-f69d1a34050a)
![스크린샷 2025-02-14 221906](https://github.com/user-attachments/assets/50edfa7f-1dad-4ae3-b83e-c0427d8bb79d)
![스크린샷 2025-02-14 221911](https://github.com/user-attachments/assets/ecd5f890-ebb0-4c00-9681-1d47fa74f57d)

## 📢 노트
