### PR TITLE
#11

### DIFF
--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -99,7 +99,7 @@ public class AptServiceImpl implements AptService{
         List<MngCost> mngCosts = defaultIfNull(mngCostRepository.findByDetailAptsId(detailApts.getId()), Collections.emptyList());
 
         // #3. 세대수 가져오기
-        long numberOfUnits = defaultIfNull(apts.getNmhsh(), 0).longValue();
+        long numberOfUnits = defaultIfNull(detailApts.getNumberOfUnits(), 0).longValue();
 
         // #4. 월별 관리비 계산 (세대수 이용)
         List<AptInfo.MonthlyMaintenanceData> monthlyMaintenanceData = mngCosts.stream()


### PR DESCRIPTION
## 📌 이슈 번호
> #11 
## 💬 리뷰 포인트
> 아파트 기본정보 조회 API 구현 - 리펙토링
## 🚀 상세 설명
> AptServiceImpl 의 아파트 기본정보조회 코드의 변수를 수정
(세부내용) 세대수에 해당하는 변수를 Apts 의 nmhsh에서 -> DetailApts 의 number_of_units로 변경
(변경사유) 관리비 상세내역 조회 API에서, 한 세대당 관리비를 계산할 때도, number_of_units를 사용했었기에 통일화를 시켜주는 작업이다.
## 📸 스크린샷
![스크린샷 2025-02-14 223805](https://github.com/user-attachments/assets/595f61bc-27d5-40c5-b907-26514de26566)

## 📢 노트
