### PR TITLE
:bug: Feat[#11]

### DIFF
--- a/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
+++ b/src/main/java/com/myapt/domain/apt/entity/DetailApts.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Table(name = "DetailApts")
 public class DetailApts {
 

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -93,7 +93,8 @@ public class AptServiceImpl implements AptService{
     public AptInfo getApartmentInfo(String aptsId) {
         // #1. apts_id를 사용해서, Apts와 DetailApts의 리포지토리들로부터 아파트 기본 정보를 받아온다.
         Apts apts = aptRepository.findById(aptsId).orElseThrow(() -> new RuntimeException("아파트 기본정보 데이터를 조회할 수 없습니다."));
-        DetailApts detailApts = detailAptsRepository.findByApts_Id(aptsId).orElseThrow(() -> new RuntimeException("아파트 상세정보 데이터를 조회할 수 없습니다."));
+        Optional<DetailApts> optionalDetailApts = detailAptsRepository.findByApts_Id(aptsId);
+        DetailApts detailApts = optionalDetailApts.orElse(new DetailApts()); // 기본값을 가지는 새로운 객체 생성
 
         // #2. detail_apts_id(아파트 관리비 코드)에 해당하는 월별 관리비를 계산 및 나머지 요소들과 함께 아파트 기본정보를 반환하는 코드
         List<MngCost> mngCosts = defaultIfNull(mngCostRepository.findByDetailAptsId(detailApts.getId()), Collections.emptyList());


### PR DESCRIPTION
…partmentInfo 코드 수정

## 📌 이슈 번호
>  #11 
## 💬 리뷰 포인트
> 아파트 상세정보가 비어있는경우, 기본값을 반환하도록 에러 수정
## 🚀 상세 설명
(문제상황)아파트 기본 정보 조회시, 기본키 aptID로 아파트 상세정보를 조회했을 때 해당 DetailApts 객체가 존재하지 않는 경우 500에러를 반환하는 에러가 발생
(원인) DetailApts 객체가 존재하지 않을 경우 RuntimeException을 던지게끔 코드를 설계 했기 때문
(개선상황) 기본값으로 구성된 new DetailApts객체를 생성해서 클라이언트로 반환하도록 에러 수정
## 📸 스크린샷
![스크린샷 2025-02-15 170158](https://github.com/user-attachments/assets/6c335927-9024-483e-875a-7fbed27c5d5c)
![스크린샷 2025-02-15 161928](https://github.com/user-attachments/assets/1ab18064-467d-47e4-9625-fc787d3fdb7f)
## 📢 노트
