### PR TITLE
[FEAT] 메인 지도 검색 API 추가

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/MapController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/MapController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.myapt.domain.apt.dto.MapMarkerInfo;
 import com.myapt.domain.apt.service.MapService;
@@ -31,5 +32,20 @@ public class MapController {
 		@RequestParam double maxLo) {
 		List<MapMarkerInfo> data = mapService.getMapMarkers(type.trim(), minLa, minLo, maxLa, maxLo);
 		return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
+	}
+
+	@GetMapping("/search/{type}")
+	public ResTemplate<List<MapMarkerInfo>> searchApts(
+		@PathVariable String type,
+		@RequestParam String keyword) {
+		try {
+			List<MapMarkerInfo> data = mapService.searchApts(type.trim(), keyword);
+			return new ResTemplate<>(HttpStatus.OK, "아파트 검색 성공", data);
+		} catch (ResponseStatusException e) {
+			if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
+				return new ResTemplate<>(HttpStatus.NO_CONTENT, "검색결과가 없습니다", null);
+			}
+			throw e;
+		}
 	}
 }

--- a/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
@@ -28,4 +28,10 @@ public interface AptRepository extends JpaRepository<Apts, Long> {
         @Param("minLo") double minLo,
         @Param("maxLo") double maxLo
     );
+
+    @Query("SELECT a FROM Apts a WHERE a.aptNm LIKE %:keyword% OR a.rdnmadr LIKE %:keyword%")
+    List<Apts> findByAptNmContainingOrRdnmadrContaining(@Param("keyword") String keyword);
+
+    @Query("SELECT a FROM Apts a WHERE a.isDefect = true AND (a.aptNm LIKE %:keyword% OR a.rdnmadr LIKE %:keyword%)")
+    List<Apts> findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/myapt/domain/apt/service/MapService.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapService.java
@@ -6,4 +6,5 @@ import com.myapt.domain.apt.dto.MapMarkerInfo;
 
 public interface MapService {
 	public List<MapMarkerInfo> getMapMarkers(String type, double minLa, double minLo, double maxLa, double maxLo);
+	List<MapMarkerInfo> searchApts(String type, String keyword);
 }

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -3,7 +3,9 @@ package com.myapt.domain.apt.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.myapt.domain.apt.dto.MapMarkerInfo;
 import com.myapt.domain.apt.exception.MarkerNotFoundException;
@@ -46,5 +48,30 @@ public class MapServiceImpl implements MapService {
 		}
 
 		return markers;
+	}
+
+	@Override
+	public List<MapMarkerInfo> searchApts(String type, String keyword) {
+		List<MapMarkerInfo> results;
+
+		// 공백 제거 후 비교
+		if ("defect".equals(type.trim().toLowerCase())) {
+			results = aptRepository.findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(keyword)
+				.stream()
+				.map(apt -> MapMarkerInfo.of(apt.getId(), apt.getAptNm(), apt.getLa(), apt.getLo()))
+				.collect(Collectors.toList());
+		} else {
+			results = aptRepository.findByAptNmContainingOrRdnmadrContaining(keyword)
+				.stream()
+				.map(apt -> MapMarkerInfo.of(apt.getId(), apt.getAptNm(), apt.getLa(), apt.getLo()))
+				.collect(Collectors.toList());
+		}
+
+		// 검색 결과가 없을 경우
+		if (results.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NO_CONTENT);
+		}
+		
+		return results;
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #20
## 💬 리뷰 포인트
> 메인 검색 API 구현
## 🚀 상세 설명
path variable 로 부실아파트 검색인지 일반 아파트 검색인지 구분 해두었습니다.
레이턴시를 줄이기 위해 쿼리문을 이용해서 구현 해뒀어요..!
다만, 데이터가 늘어나면 늘어날 수록 레이턴시가 늘어나니까 차후에 업데이트 하도록 하겠습니다!

## 📸 스크린샷
> 성공
<img width="515" alt="image" src="https://github.com/user-attachments/assets/a92657dc-93b3-44ba-bd8a-1b010d54f9ae" />

> 데이터 없을 경우 - 204
<img width="518" alt="image" src="https://github.com/user-attachments/assets/df49fcb6-fd92-4625-86d4-f99de69b6694" />


## 📢 노트