### PR TITLE
Feat/news #9

### DIFF
--- a/src/main/java/com/myapt/domain/news/controller/NewsController.java
+++ b/src/main/java/com/myapt/domain/news/controller/NewsController.java
@@ -2,16 +2,15 @@ package com.myapt.domain.news.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.myapt.domain.news.dto.NewsPageRequest;
 import com.myapt.domain.news.dto.NewsResponse;
+import com.myapt.domain.news.exception.NewsTypeNotFoundException;
 import com.myapt.domain.news.service.NewsServiceImpl;
 import com.myapt.global.template.ResTemplate;
 
@@ -26,13 +25,16 @@ public class NewsController {
 
 	@PostMapping("/{type}")
 	public ResTemplate<NewsResponse> getNews(
-			@PathVariable String type,
-			@RequestBody NewsPageRequest newsPageRequest) {
+		@PathVariable String type,
+		@RequestBody NewsPageRequest newsPageRequest) {
 		NewsResponse data;
 		if (type.equals("apt")) {
 			data = newsService.getNews("아파트", newsPageRequest.pages(), newsPageRequest.num(), newsPageRequest.sort());
+		} else if (type.equals("defect")) {
+			data = newsService.getNews("부실 아파트", newsPageRequest.pages(), newsPageRequest.num(),
+				newsPageRequest.sort());
 		} else {
-			data = newsService.getNews("부실 아파트", newsPageRequest.pages(), newsPageRequest.num(), newsPageRequest.sort());
+			throw new NewsTypeNotFoundException();
 		}
 		return new ResTemplate<>(HttpStatus.OK, "뉴스 조회 성공", data);
 	}

--- a/src/main/java/com/myapt/domain/news/entity/News.java
+++ b/src/main/java/com/myapt/domain/news/entity/News.java
@@ -40,7 +40,9 @@ public class News {
 
 	//기타
 	@Builder
-	private News(String platform, String image, String title, String content, String url, LocalDateTime createdAt, LocalDateTime updatedAt) {
+	private News(String type, String platform, String image, String title, String content, String url,
+		LocalDateTime createdAt, LocalDateTime updatedAt) {
+		this.type = type;
 		this.platform = platform;
 		this.image = image;
 		this.title = title;

--- a/src/main/java/com/myapt/domain/news/exception/NewsTypeNotFoundException.java
+++ b/src/main/java/com/myapt/domain/news/exception/NewsTypeNotFoundException.java
@@ -1,0 +1,14 @@
+package com.myapt.domain.news.exception;
+
+import com.myapt.global.error.exception.NotFoundGroupException;
+
+public class NewsTypeNotFoundException extends NotFoundGroupException {
+	public NewsTypeNotFoundException(String message) {
+		super(message);
+	}
+
+	public NewsTypeNotFoundException() {
+		super("해당 뉴스 타입은 존재하지 않습니다.");
+	}
+
+}

--- a/src/main/java/com/myapt/domain/news/repository/NewsApiResponseRepository.java
+++ b/src/main/java/com/myapt/domain/news/repository/NewsApiResponseRepository.java
@@ -35,7 +35,7 @@ public class NewsApiResponseRepository {
 			RestTemplate restTemplate = new RestTemplate();
 			HttpHeaders headers = getNaverApiRequestHeaders();
 
-			String url = "https://openapi.naver.com/v1/search/news.json?query=" + keyword + "&display=50";
+			String url = "https://openapi.naver.com/v1/search/news.json?query=" + keyword + "&display=50&sort=date";
 			ResponseEntity<NewsApiResponse> newsApiResponseDtoEntity = restTemplate.exchange(url, HttpMethod.GET,
 				new HttpEntity<>(headers), NewsApiResponse.class);
 			if (newsApiResponseDtoEntity.getStatusCode().is2xxSuccessful()) {

--- a/src/main/java/com/myapt/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/myapt/domain/news/repository/NewsRepository.java
@@ -1,5 +1,9 @@
 package com.myapt.domain.news.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +11,7 @@ import com.myapt.domain.news.entity.News;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
+	Page<News> findAllByType(Pageable pageable, String type);
+
+	Optional<News> findFirstByTypeOrderByIdDesc(String type);
 }

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -1,8 +1,11 @@
 package com.myapt.domain.news.service;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,27 +34,125 @@ public class NewsServiceImpl implements NewsService {
 	private final NewsApiResponseRepository newsApiResponseRepository;
 	private final NewsRepository newsRepository;
 
-	// 30분마다 실행되는 메서드
+	// 부실 뉴스 캐시 역할을 하는 set (동시 접근 대비 동기화)
+	private final LinkedHashSet<String> defectNewsUrlCache = new LinkedHashSet<>();
+	// 캐시 최대 용량 (API 조회 크기의 2배)
+	private final int DEFECT_CACHE_CAPACITY = 100;
+
+	/*
+	 30분마다 실행되는 스케줄러 메서드
+	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
+	 */
 	@Override
-	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
+	@Scheduled(fixedRate = 180000)  // 30분 = 30 * 60 * 1000 밀리초
 	public void crawlAndSaveNews() {
 		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
 
 		try {
-			// 예시로 특정 키워드로 검색, 필요에 따라 변경 가능
-			String keyword = "부동산";
-			NewsApiResponse newsApiResponseDto = newsApiResponseRepository.getNewsApiResponseDto(keyword)
-				.orElseThrow(NewsNullException::new);
-			List<NewsCrawlingResponse> newsResponseDtos = newsApiResponseDto.getNewsResponseDtoWithImages();
-			saveNews(newsResponseDtos);
-			log.info("Completed news crawling and saving.");
+			processDefectNews();
+			processNormalNews();
 		} catch (Exception e) {
 			log.error("Error during scheduled news crawling", e);
 		}
 	}
 
+	/*
+	 부실(Defect) 뉴스 처리
+	 1. 부실 뉴스 API 조회
+	 2. DB에 이미 저장된 뉴스와 중복 제거
+	 3. 캐시에 신규 부실 뉴스 URL 추가 (용량 초과 시 오래된 URL 삭제)
+	 4. DB에 부실 뉴스 저장
+	 */
+	private void processDefectNews() {
+		String defectKeyword = "아파트 부실 시공 공사";
+
+		// 부실 뉴스 조회
+		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
+			.orElseThrow(NewsNullException::new);
+		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoWithImages();
+
+		// DB에 이미 저장된 뉴스와 중복되는 항목 제거
+		defectNewsList = filterDuplicateNewsInDB(defectNewsList, "부실 아파트");
+
+		// 캐시(set)에 신규 부실 뉴스 추가 (용량 초과 시 오래된 요소 삭제)
+		addToDefectCache(defectNewsList);
+
+		// 부실 뉴스 DB 저장
+		saveNews(defectNewsList, "부실 아파트");
+		log.info("Completed defect news crawling and saving.");
+	}
+
+	/*
+	 일반 뉴스 처리
+	 1. 일반 뉴스 API 조회
+	 2. DB에 이미 저장된 뉴스와 중복 제거
+	 3. 부실 뉴스 캐시 URL에 포함된 뉴스 제거 (중복 제거)
+	 4. DB에 일반 뉴스 저장
+	 */
+	private void processNormalNews() {
+		String normalKeyword = "아파트 부동산";
+
+		// 일반 뉴스 조회
+		NewsApiResponse normalNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(normalKeyword)
+			.orElseThrow(NewsNullException::new);
+		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoWithImages();
+
+		// DB에 이미 저장된 뉴스 제거
+		normalNewsList = filterDuplicateNewsInDB(normalNewsList, "아파트");
+
+		// 캐시(set)에 저장된 부실 뉴스와 중복되는 일반 뉴스 제거
+		normalNewsList = filterDuplicateNewsInDefectCache(normalNewsList);
+
+		// 일반 뉴스 DB 저장
+		saveNews(normalNewsList, "아파트");
+		log.info("Completed normal news crawling and saving.");
+	}
+
+	/*
+	 신규 부실 뉴스의 URL을 캐시에 추가하는 메서드
+	 만약 캐시가 최대 용량을 초과하면, 오래된 URL부터 삭제 후 추가
+	 */
+	private void addToDefectCache(List<NewsCrawlingResponse> newsList) {
+		int removeSize = defectNewsUrlCache.size() + newsList.size() - DEFECT_CACHE_CAPACITY;
+		for (int i = 0; i < removeSize; i++) {
+			defectNewsUrlCache.removeFirst();
+		}
+		List<String> urlList = newsList.stream().map(NewsCrawlingResponse::getLink).toList();
+		defectNewsUrlCache.addAll(urlList);
+	}
+
+	/*
+	 DB에 이미 저장된 뉴스와 비교하여 중복되는 항목을 제거
+	 뉴스 URL 기준으로 중복 여부를 판단
+	 */
+	private List<NewsCrawlingResponse> filterDuplicateNewsInDB(List<NewsCrawlingResponse> newsList, String newsType) {
+		// DB에 저장된 같은 타입의 뉴스 중에서 가장 최근 뉴스의 URL 가져온다
+		Optional<News> lastNewsOpt = newsRepository.findFirstByTypeOrderByIdDesc(newsType);
+		if (lastNewsOpt.isEmpty()) {
+			return newsList;
+		}
+		String lastNewsUrl = lastNewsOpt.get().getUrl();
+
+		// 뉴스 리스트에서 DB에 저장된 최신 뉴스(및 그 이전 뉴스)는 제거
+		int duplicateNewsIndex = IntStream.range(0, newsList.size())
+			.filter(i -> newsList.get(i).getLink().equals(lastNewsUrl))
+			.findFirst()
+			.orElse(-1);
+
+		return newsList.subList(duplicateNewsIndex + 1, newsList.size());
+	}
+
+	/*
+	 일반 뉴스 리스트에서 부실 뉴스 캐시 URL과 중복되는 뉴스를 제거
+	 */
+	private List<NewsCrawlingResponse> filterDuplicateNewsInDefectCache(List<NewsCrawlingResponse> newsList) {
+		return newsList.stream()
+			.filter(news -> !defectNewsUrlCache.contains(news.getLink()))
+			.collect(Collectors.toList());
+	}
+
 	@Override
-	public NewsResponse getNews (String keyword, int page, int size, String sort){
+	public NewsResponse getNews(String keyword, int page, int size, String sort) {
 		if (page <= 0) {
 			throw new NewsNullException();
 		}
@@ -64,8 +165,8 @@ public class NewsServiceImpl implements NewsService {
 		}
 
 		Pageable pageable = PageRequest.of(page - 1, size, sorting);
-		Page<News> newsPage = newsRepository.findAll(pageable);
-		// 키워드에 맞춰 일반 뉴스인지, 부실 뉴스인지 구분 필요
+		// 키워드에 맞춰 일반 뉴스인지, 부실 뉴스인지 구분
+		Page<News> newsPage = newsRepository.findAllByType(pageable, keyword);
 
 		if (newsPage.isEmpty()) {
 			return new NewsResponse(List.of(), 0);
@@ -78,15 +179,16 @@ public class NewsServiceImpl implements NewsService {
 		return new NewsResponse(newsList, newsPage.getTotalElements());
 	}
 
-	private void saveNews(List<NewsCrawlingResponse> newsResponseDtos) {
+	private void saveNews(List<NewsCrawlingResponse> newsResponseDtos, String newsType) {
 		List<News> newsList = newsResponseDtos.stream()
-			.map(this::mapToNewsEntity)
+			.map(news -> mapToNewsEntity(news, newsType))
 			.collect(Collectors.toList());
 		newsRepository.saveAll(newsList);
 	}
 
-	private News mapToNewsEntity(NewsCrawlingResponse dto) {
+	private News mapToNewsEntity(NewsCrawlingResponse dto, String type) {
 		return News.builder()
+			.type(type)
 			.platform("Naver")
 			.image(dto.getImageLink())
 			.title(dto.getTitle())

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -44,7 +44,7 @@ public class NewsServiceImpl implements NewsService {
 	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
 	 */
 	@Override
-	@Scheduled(fixedRate = 180000)  // 30분 = 30 * 60 * 1000 밀리초
+	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
 	public void crawlAndSaveNews() {
 		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
 


### PR DESCRIPTION
## 📌 이슈 번호
> #9 
## 💬 리뷰 포인트
> 뉴스를 저장하는 스케줄러에서 부실/일반 뉴스 처리하는 부분에서 중복 제거하는 부분 확인해 주세요
## 🚀 상세 설명
1. 뉴스 크롤링 로직을 부실 아파트 뉴스와 일반 아파트 뉴스로 분리해서 처리
2. 부실 아파트 뉴스 처리 시, DB에 이미 저장된 뉴스와의 중복 제거를 위해 DB에 저장된 가장 최신 뉴스의 URL을 기준으로 필터링합니다 
3. 일반 아파트 뉴스 처리에서는 DB에 이미 저장된 뉴스와의 중복 제거하고 부실 아파트 뉴스 캐시를 참조하여 부실 아파트 뉴스와 중복되는 항목을 제거합니다
4. POST /news/{type} 요청을 통해 조회하고, {type} 경로변수는 "apt" 또는 "defect" 만 가능합니다, 잘못된 타입 입력 시 예외 발생시킵니다.
## 📸 스크린샷
> 성공 (부실 아파트 뉴스 조회)
<img width="515" alt="image" src="https://github.com/user-attachments/assets/e6e3361a-b5ad-4558-b6f5-09e186f9c5a1"/>

> 성공 (일반 아파트 뉴스 조회)
<img width="515" alt="image" src="https://github.com/user-attachments/assets/6e290495-acdd-4b96-85b8-4d9a9f38ace3"/>

> 실패 (잘못된 경로변수)
<img width="515" alt="image" src="https://github.com/user-attachments/assets/8d3de064-aa0d-4adb-aefc-14d6f2d6d8e5"/>

## 📢 노트