### PR TITLE
[FEAT] 뉴스 API 고도화 - 본문 늘리기 및 이미지 null 처리

### DIFF
--- a/src/main/java/com/myapt/domain/news/dto/NewsApiResponse.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsApiResponse.java
@@ -14,7 +14,6 @@ public class NewsApiResponse {
 	@JsonSetter("items")
 	private List<NewsSummaryDto> items;
 
-
 	//getNaverNews : items로 부터 네이버 뉴스에 등록된 모든 items를 반환합니다.
 	public List<NewsSummaryDto> getNaverNews() {
 		return items.stream()
@@ -22,15 +21,14 @@ public class NewsApiResponse {
 			.collect(Collectors.toList());
 	}
 
-
 	/*
-	getOnlyNaverNews를 이용하여 필터링 된 뉴스들을 활용
+	getOnlyNaverNews를 이용하여 필터링 된 뉴스들을 활용 => 다양한 플랫폼 뉴스를 얻기 위해 getNaverNews 제거
 	JsoupCrawling 객체를 주입하여 크롤링을 수행한 뒤
 	validateImageLink를 통해 이미지가 있는 데이터들로 한번더 필터링하여 => 주석처리함 -> 이미지 없는 기사도 가져오려고
 	최대 20개까지 반환합니다.
 	 */
-	public List<NewsCrawlingResponse> getNewsResponseDtoWithImages() {
-		return getNaverNews().stream()
+	public List<NewsCrawlingResponse> getNewsResponseDtoList() {
+		return items.stream()
 			.map(item -> item.toNewsResponseDto(new JsoupCrawling()))
 			//.filter(NewsResponseDto::validateImageLink)
 			.limit(20L)

--- a/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
@@ -1,8 +1,6 @@
 package com.myapt.domain.news.dto;
 
-import java.util.Optional;
-
-import org.jsoup.select.Elements;
+import org.jsoup.nodes.Document;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.myapt.domain.news.util.JsoupCrawling;
@@ -22,20 +20,19 @@ public class NewsSummaryDto {
 	private String description;
 
 	public NewsCrawlingResponse toNewsResponseDto(JsoupCrawling jsoupCrawling) {
-		String query = "#contents img";
-		Optional<Elements> jsoupElements = jsoupCrawling.getJsoupElements(link, query);
-		if (jsoupElements.isPresent()) {
-			return NewsCrawlingResponse.builder()
-				.imageLink(jsoupElements.get().attr("data-src"))
-				.title(title)
-				.link(link)
-				.description(description)
-				.build();
-		}
+		// 뉴스 링크를 통해 html 문서 가져옴
+		Document document = jsoupCrawling.getDocument(link);
+		// html 문서에서 이미지 url 추출
+		String imageLink = jsoupCrawling.getImageUrl(document);
+		// html 문서에서 본문 추출(최대 길이 설정 가능)
+		String content = jsoupCrawling.getContent(document, 250);
+		content = content.length() > description.length() ? content : description;
+
 		return NewsCrawlingResponse.builder()
+			.imageLink(imageLink)
 			.title(title)
 			.link(link)
-			.description(description)
+			.description(content)
 			.build();
 	}
 }

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -69,7 +69,7 @@ public class NewsServiceImpl implements NewsService {
 		// 부실 뉴스 조회
 		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
 			.orElseThrow(NewsNullException::new);
-		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoWithImages();
+		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoList();
 
 		// DB에 이미 저장된 뉴스와 중복되는 항목 제거
 		defectNewsList = filterDuplicateNewsInDB(defectNewsList, "부실 아파트");
@@ -95,7 +95,7 @@ public class NewsServiceImpl implements NewsService {
 		// 일반 뉴스 조회
 		NewsApiResponse normalNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(normalKeyword)
 			.orElseThrow(NewsNullException::new);
-		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoWithImages();
+		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoList();
 
 		// DB에 이미 저장된 뉴스 제거
 		normalNewsList = filterDuplicateNewsInDB(normalNewsList, "아파트");

--- a/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
+++ b/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
@@ -1,18 +1,31 @@
 package com.myapt.domain.news.util;
 
+import java.io.IOException;
+import java.util.Optional;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
-import java.io.IOException;
-import java.util.Optional;
 
 /*
 connection을 생성하여 Elements를 반환
 IOException이 발생할 경우 Optional.empty()를 반환하여 NullPointerException을 방지
  */
 public class JsoupCrawling {
-	public Document getConnection(String url) throws IOException {
+	private Document getConnection(String url) throws IOException {
 		return Jsoup.connect(url).get();
+	}
+
+	/*
+	url을 통해 html 문서를 가져오는 메서드
+	연결 실패 시, null 반환
+	 */
+	public Document getDocument(String url) {
+		try {
+			return getConnection(url);
+		} catch (IOException e) {
+			return null;
+		}
 	}
 
 	public Optional<Elements> getJsoupElements(String url, String query) {
@@ -22,5 +35,27 @@ public class JsoupCrawling {
 		} catch (IOException e) {
 			return Optional.empty();
 		}
+	}
+
+	/*
+	html 문서에서 이미지를 추출하는 메서드
+	id가 contents인 태그 안에 있는 img 태그의 속성 data-src의 값을 가져옴
+	해당되는 값이 없는 경우 null 반환
+	 */
+	public String getImageUrl(Document document) {
+		String imageUrl = document.select("#contents img").attr("data-src");
+		return imageUrl.isBlank() ? null : imageUrl;
+	}
+
+	/*
+	html 문서에서 본문 내용을 추출하는 메서드
+	본문 내용이 최대 길이보다 길면, 나머지 내용은 생략
+	 */
+	public String getContent(Document document, Integer maxLength) {
+		String text = document.text();
+		if (text.length() > maxLength) {
+			text = text.substring(0, maxLength - 3) + "...";
+		}
+		return text;
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #9  
## 💬 리뷰 포인트
> 뉴스 기사 본문 처리 로직 추가 및 이미지 없는 경우 null 반환
## 🚀 상세 설명
1. 뉴스 설명 내용 추가하는 로직 추가했습니다. 최대 길이(250자)를 초과할 경우, 나머지는 생략합니다. 
2. 이미지 없는 경우 null 값을 저장하도록 수정했습니다. 
## 📸 스크린샷
> 본문 처리 로직 및 이미지 null 처리 확인  
<img width="515" alt="image" src="https://github.com/user-attachments/assets/fa390f55-e3c9-4ba5-80a8-b75e5ec943b2" />

## 📢 노트