### PR TITLE
[FEAT] 뉴스 API 고도화 - 플랫폼 추출 및 이미지 null 처리

### DIFF
--- a/src/main/java/com/myapt/domain/news/dto/NewsApiResponse.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsApiResponse.java
@@ -22,13 +22,13 @@ public class NewsApiResponse {
 	}
 
 	/*
-	getOnlyNaverNews를 이용하여 필터링 된 뉴스들을 활용 => 다양한 플랫폼 뉴스를 얻기 위해 getNaverNews 제거
+	getNaverNews를 이용하여 필터링 된 뉴스들을 활용
 	JsoupCrawling 객체를 주입하여 크롤링을 수행한 뒤
 	validateImageLink를 통해 이미지가 있는 데이터들로 한번더 필터링하여 => 주석처리함 -> 이미지 없는 기사도 가져오려고
 	최대 20개까지 반환합니다.
 	 */
 	public List<NewsCrawlingResponse> getNewsResponseDtoList() {
-		return items.stream()
+		return getNaverNews().stream()
 			.map(item -> item.toNewsResponseDto(new JsoupCrawling()))
 			//.filter(NewsResponseDto::validateImageLink)
 			.limit(20L)

--- a/src/main/java/com/myapt/domain/news/dto/NewsCrawlingResponse.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsCrawlingResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class NewsCrawlingResponse {
+	private String platform;
 	private String title;
 	private String link;
 	private String description;

--- a/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
@@ -19,20 +19,42 @@ public class NewsSummaryDto {
 	@JsonSetter("description")
 	private String description;
 
+	/*
+		뉴스 링크를 통해 HTML 문서를 가져와 크롤링을 수행하고
+		NewsCrawlingResponse 객체로 변환하는 메서드입니다
+		1. 뉴스 링크로 HTML 문서를 가져옴
+		2. document가 null일 경우, 기본 데이터(네이버 뉴스 api 결과)로 객체 생성
+		3. 정상적으로 로드되면 필요한 정보를 document에서 추출하여 객체 생성
+	*/
 	public NewsCrawlingResponse toNewsResponseDto(JsoupCrawling jsoupCrawling) {
 		// 뉴스 링크를 통해 html 문서 가져옴
 		Document document = jsoupCrawling.getDocument(link);
+		if (document == null) {
+			// document가 null인 경우 기본 값 또는 원본 데이터를 사용하여 응답 생성
+			return NewsCrawlingResponse.builder()
+				.platform("Naver")
+				.imageLink(link)
+				.title(title)
+				.link(link)
+				.description(description)
+				.build();
+		}
+
+		// html 문서에서 플랫폼 추출
+		String extractedPlatform = jsoupCrawling.getPlatform(document);
 		// html 문서에서 이미지 url 추출
-		String imageLink = jsoupCrawling.getImageUrl(document);
+		String extractedImageLink = jsoupCrawling.getImageUrl(document);
+		// html 문서에서 제목 추출
+		String extractedTitle = jsoupCrawling.getTitle(document);
 		// html 문서에서 본문 추출(최대 길이 설정 가능)
-		String content = jsoupCrawling.getContent(document, 250);
-		content = content.length() > description.length() ? content : description;
+		String extractedContent = jsoupCrawling.getContent(document, 255);
 
 		return NewsCrawlingResponse.builder()
-			.imageLink(imageLink)
-			.title(title)
+			.platform((extractedPlatform != null) ? extractedPlatform : "Naver")
+			.imageLink((extractedImageLink != null) ? extractedImageLink : link)
+			.title((extractedTitle != null) ? extractedTitle : title)
 			.link(link)
-			.description(content)
+			.description((extractedContent != null) ? extractedContent : description)
 			.build();
 	}
 }

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -189,7 +189,7 @@ public class NewsServiceImpl implements NewsService {
 	private News mapToNewsEntity(NewsCrawlingResponse dto, String type) {
 		return News.builder()
 			.type(type)
-			.platform("Naver")
+			.platform(dto.getPlatform())
 			.image(dto.getImageLink())
 			.title(dto.getTitle())
 			.content(dto.getDescription())

--- a/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
+++ b/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
@@ -5,13 +5,13 @@ import java.util.Optional;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-/*
-connection을 생성하여 Elements를 반환
-IOException이 발생할 경우 Optional.empty()를 반환하여 NullPointerException을 방지
- */
 public class JsoupCrawling {
+	/*
+	connection을 생성하여 Document를 반환
+	 */
 	private Document getConnection(String url) throws IOException {
 		return Jsoup.connect(url).get();
 	}
@@ -39,12 +39,22 @@ public class JsoupCrawling {
 
 	/*
 	html 문서에서 이미지를 추출하는 메서드
-	id가 contents인 태그 안에 있는 img 태그의 속성 data-src의 값을 가져옴
+	meta 태그 중 property가 og:image인 태그의 content 속성 값을 가져옴
 	해당되는 값이 없는 경우 null 반환
 	 */
 	public String getImageUrl(Document document) {
-		String imageUrl = document.select("#contents img").attr("data-src");
-		return imageUrl.isBlank() ? null : imageUrl;
+		Element image = document.selectFirst("meta[property=og:image]");
+		return (image != null) ? image.attr("content") : null;
+	}
+
+	/*
+		html 문서에서 플랫폼 정보를 추출하는 메서드
+		meta 태그 중 name이 twitter:creator인 태그의 content 속성 값을 가져옴
+		해당 태그가 없으면 null 반환
+	 */
+	public String getPlatform(Document document) {
+		Element platform = document.selectFirst("meta[name=twitter:creator]");
+		return (platform != null) ? platform.attr("content") : null;
 	}
 
 	/*
@@ -52,10 +62,27 @@ public class JsoupCrawling {
 	본문 내용이 최대 길이보다 길면, 나머지 내용은 생략
 	 */
 	public String getContent(Document document, Integer maxLength) {
-		String text = document.text();
+		Element content = document.selectFirst("#newsct_article");
+		if (content == null) {
+			return null;
+		}
+		String text = content.text();
 		if (text.length() > maxLength) {
 			text = text.substring(0, maxLength - 3) + "...";
 		}
 		return text;
+	}
+
+	/*
+	html 문서에서 제목을 추출하는 메서드
+	meta 태그 중 property가 og:title인 태그의 content 속성 값을 가져옴
+	해당되는 값이 없는 경우 null 반환
+	 */
+	public String getTitle(Document document) {
+		Element title = document.selectFirst("meta[property=og:title]");
+		if (title == null) {
+			return null;
+		}
+		return title.attr("content");
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #9

## 💬 리뷰 포인트
> 뉴스 크롤링 응답 생성 시 이미지, 플랫폼, 내용, 제목 추출하는 로직 개선
> 뉴스 크롤링 응답 생성 시 document null 처리 추가

## 🚀 상세 설명
1. NewsCrawlingResponse에 platform 필드 추가하여 뉴스의 플랫폼 정보를 담도록 수정
2. 뉴스 HTML 문서 크롤링해서 추가 정보 추출하는 작업 수정
    - 이미지 추출하는 메서드 수정, meta태그에 있는 og:image 속성값을 추출하는 방식으로 변경 속성값이 없다면 null 반환
    - 플랫폼 추출하는 메서드 추가, meta태그에 있는 twitter:creator 속성값 추출하는 방식으로 변경 속성값이 없다면 null 반환
    - 뉴스 내용 추출하는 메서드 수정, id가 newsct_article인 태그의 내용을 추출하는 방식으로 변경 속성값이 없다면 null 반환
    - 제목 추출하는 메서드 추가, meta태그에 있는 og:title 속성값 추출하는 방식으로 변경 속성값이 없다면 null 반환
3. 뉴스 HTML 문서 로드 실패 시, 네이버 뉴스 api 응답 적용

## 📸 스크린샷
> 네이버 필터 적용 및 뉴스 데이터 추출 결과 확인 
<img width="515" alt="image" src="https://github.com/user-attachments/assets/09a870fa-13f9-47f7-bce3-6d745769fbd0" />

## 📢 노트