### PR TITLE
[FEAT] 지도 API 수정

### DIFF
--- a/src/main/java/com/myapt/domain/apt/controller/MapController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/MapController.java
@@ -35,14 +35,12 @@ public class MapController {
 		@RequestParam double maxLa,
 		@RequestParam double maxLo) {
 		List<MapMarkerInfo> data = mapService.getMapMarkers(type.trim(), minLa, minLo, maxLa, maxLo);
-		try {
-			return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
-		} catch (ResponseStatusException e) {
-			if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
-				return new ResTemplate<>(HttpStatus.NO_CONTENT, "마커가 없습니다", null);
-			}
-			throw e;
+
+		// 마커가 없을 경우
+		if (data.isEmpty()) {
+			return new ResTemplate<>(HttpStatus.NO_CONTENT, "마커가 없습니다", null);
 		}
+		return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
 	}
 
 	@GetMapping("/search/{type}")
@@ -51,17 +49,15 @@ public class MapController {
 		@RequestParam String keyword,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "5") int num) {
-		try {
-			PageRequest pageRequest = PageRequest.of(page - 1, num); // PageRequest는 0부터 시작
-			Page<MapSearchInfo> dataPage = mapService.searchApts(type.trim(), keyword, pageRequest);
-			List<MapSearchInfo> data = dataPage.getContent();
-			SearchResponse response = SearchResponse.of(dataPage.getTotalElements(), data);
-			return new ResTemplate<>(HttpStatus.OK, "검색완료", response);
-		} catch (ResponseStatusException e) {
-			if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
-				return new ResTemplate<>(HttpStatus.NO_CONTENT, "검색결과가 없습니다", null);
-			}
-			throw e;
+		PageRequest pageRequest = PageRequest.of(page - 1, num);
+		Page<MapSearchInfo> dataPage = mapService.searchApts(type.trim(), keyword, pageRequest);
+		List<MapSearchInfo> data = dataPage.getContent();
+
+		// 검색결과가 없을 경우
+		if (data.isEmpty()) {
+			return new ResTemplate<>(HttpStatus.NO_CONTENT, "검색결과가 없습니다", null);
 		}
+		SearchResponse response = SearchResponse.of(dataPage.getTotalElements(), data);
+		return new ResTemplate<>(HttpStatus.OK, "검색완료", response);
 	}
 }

--- a/src/main/java/com/myapt/domain/apt/controller/MapController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/MapController.java
@@ -31,7 +31,14 @@ public class MapController {
 		@RequestParam double maxLa,
 		@RequestParam double maxLo) {
 		List<MapMarkerInfo> data = mapService.getMapMarkers(type.trim(), minLa, minLo, maxLa, maxLo);
-		return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
+		try {
+			return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", data);
+		} catch (ResponseStatusException e) {
+			if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
+				return new ResTemplate<>(HttpStatus.NO_CONTENT, "마커가 없습니다", null);
+			}
+			throw e;
+		}
 	}
 
 	@GetMapping("/search/{type}")

--- a/src/main/java/com/myapt/domain/apt/controller/MapController.java
+++ b/src/main/java/com/myapt/domain/apt/controller/MapController.java
@@ -2,6 +2,8 @@ package com.myapt.domain.apt.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.myapt.domain.apt.dto.MapMarkerInfo;
+import com.myapt.domain.apt.dto.MapSearchInfo;
+import com.myapt.domain.apt.dto.SearchResponse;
 import com.myapt.domain.apt.service.MapService;
 import com.myapt.global.template.ResTemplate;
 
@@ -42,12 +46,17 @@ public class MapController {
 	}
 
 	@GetMapping("/search/{type}")
-	public ResTemplate<List<MapMarkerInfo>> searchApts(
+	public ResTemplate<SearchResponse> searchApts(
 		@PathVariable String type,
-		@RequestParam String keyword) {
+		@RequestParam String keyword,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "5") int num) {
 		try {
-			List<MapMarkerInfo> data = mapService.searchApts(type.trim(), keyword);
-			return new ResTemplate<>(HttpStatus.OK, "아파트 검색 성공", data);
+			PageRequest pageRequest = PageRequest.of(page - 1, num); // PageRequest는 0부터 시작
+			Page<MapSearchInfo> dataPage = mapService.searchApts(type.trim(), keyword, pageRequest);
+			List<MapSearchInfo> data = dataPage.getContent();
+			SearchResponse response = SearchResponse.of(dataPage.getTotalElements(), data);
+			return new ResTemplate<>(HttpStatus.OK, "검색완료", response);
 		} catch (ResponseStatusException e) {
 			if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
 				return new ResTemplate<>(HttpStatus.NO_CONTENT, "검색결과가 없습니다", null);

--- a/src/main/java/com/myapt/domain/apt/dto/MapSearchInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MapSearchInfo.java
@@ -1,0 +1,22 @@
+package com.myapt.domain.apt.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MapSearchInfo(
+	String aptId,
+	String aptName,
+	String aptAddress,
+	Double latitude,
+	Double longitude
+) {
+	public static MapSearchInfo of(String aptId, String aptName, String aptAddress, Double latitude, Double longitude) {
+		return MapSearchInfo.builder()
+			.aptId(aptId)
+			.aptName(aptName)
+			.aptAddress(aptAddress)
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/dto/SearchResponse.java
+++ b/src/main/java/com/myapt/domain/apt/dto/SearchResponse.java
@@ -1,0 +1,18 @@
+package com.myapt.domain.apt.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record SearchResponse(
+	Long totalElements,
+	List<MapSearchInfo> results
+) {
+	public static SearchResponse of(Long totalElements, List<MapSearchInfo> results) {
+		return SearchResponse.builder()
+			.totalElements(totalElements)
+			.results(results)
+			.build();
+	}
+}

--- a/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
+++ b/src/main/java/com/myapt/domain/apt/repository/AptRepository.java
@@ -1,6 +1,9 @@
 package com.myapt.domain.apt.repository;
 
 import com.myapt.domain.apt.entity.Apts;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,9 +32,11 @@ public interface AptRepository extends JpaRepository<Apts, Long> {
         @Param("maxLo") double maxLo
     );
 
-    @Query("SELECT a FROM Apts a WHERE a.aptNm LIKE %:keyword% OR a.rdnmadr LIKE %:keyword%")
-    List<Apts> findByAptNmContainingOrRdnmadrContaining(@Param("keyword") String keyword);
-
     @Query("SELECT a FROM Apts a WHERE a.isDefect = true AND (a.aptNm LIKE %:keyword% OR a.rdnmadr LIKE %:keyword%)")
-    List<Apts> findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(@Param("keyword") String keyword);
+    Page<Apts> findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(
+        @Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT a FROM Apts a WHERE a.aptNm LIKE %:keyword% OR a.rdnmadr LIKE %:keyword%")
+    Page<Apts> findByAptNmContainingOrRdnmadrContaining(
+        @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/myapt/domain/apt/service/MapService.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapService.java
@@ -2,9 +2,13 @@ package com.myapt.domain.apt.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.myapt.domain.apt.dto.MapMarkerInfo;
+import com.myapt.domain.apt.dto.MapSearchInfo;
 
 public interface MapService {
 	public List<MapMarkerInfo> getMapMarkers(String type, double minLa, double minLo, double maxLa, double maxLo);
-	List<MapMarkerInfo> searchApts(String type, String keyword);
+	Page<MapSearchInfo> searchApts(String type, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -44,7 +44,7 @@ public class MapServiceImpl implements MapService {
 		}
 
 		if (markers.isEmpty()) {
-			throw new MarkerNotFoundException();
+			throw new ResponseStatusException(HttpStatus.NO_CONTENT);
 		}
 
 		return markers;

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -46,10 +46,6 @@ public class MapServiceImpl implements MapService {
 				.collect(Collectors.toList());
 		}
 
-		if (markers.isEmpty()) {
-			throw new ResponseStatusException(HttpStatus.NO_CONTENT);
-		}
-
 		return markers;
 	}
 
@@ -64,11 +60,6 @@ public class MapServiceImpl implements MapService {
 		} else {
 			results = aptRepository.findByAptNmContainingOrRdnmadrContaining(keyword, pageable)
 				.map(apt -> MapSearchInfo.of(apt.getId(), apt.getAptNm(), apt.getRdnmadr(), apt.getLa(), apt.getLo()));
-		}
-
-		// 검색 결과가 없을 경우
-		if (results.isEmpty()) {
-			throw new ResponseStatusException(HttpStatus.NO_CONTENT);
 		}
 
 		return results;

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -3,11 +3,14 @@ package com.myapt.domain.apt.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.myapt.domain.apt.dto.MapMarkerInfo;
+import com.myapt.domain.apt.dto.MapSearchInfo;
 import com.myapt.domain.apt.exception.MarkerNotFoundException;
 import com.myapt.domain.apt.repository.AptRepository;
 
@@ -51,27 +54,23 @@ public class MapServiceImpl implements MapService {
 	}
 
 	@Override
-	public List<MapMarkerInfo> searchApts(String type, String keyword) {
-		List<MapMarkerInfo> results;
+	public Page<MapSearchInfo> searchApts(String type, String keyword, Pageable pageable) {
+		Page<MapSearchInfo> results;
 
 		// 공백 제거 후 비교
 		if ("defect".equals(type.trim().toLowerCase())) {
-			results = aptRepository.findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(keyword)
-				.stream()
-				.map(apt -> MapMarkerInfo.of(apt.getId(), apt.getAptNm(), apt.getLa(), apt.getLo()))
-				.collect(Collectors.toList());
+			results = aptRepository.findByIsDefectTrueAndAptNmContainingOrIsDefectTrueAndRdnmadrContaining(keyword, pageable)
+				.map(apt -> MapSearchInfo.of(apt.getId(), apt.getAptNm(), apt.getRdnmadr(), apt.getLa(), apt.getLo()));
 		} else {
-			results = aptRepository.findByAptNmContainingOrRdnmadrContaining(keyword)
-				.stream()
-				.map(apt -> MapMarkerInfo.of(apt.getId(), apt.getAptNm(), apt.getLa(), apt.getLo()))
-				.collect(Collectors.toList());
+			results = aptRepository.findByAptNmContainingOrRdnmadrContaining(keyword, pageable)
+				.map(apt -> MapSearchInfo.of(apt.getId(), apt.getAptNm(), apt.getRdnmadr(), apt.getLa(), apt.getLo()));
 		}
 
 		// 검색 결과가 없을 경우
 		if (results.isEmpty()) {
 			throw new ResponseStatusException(HttpStatus.NO_CONTENT);
 		}
-		
+
 		return results;
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #20 
## 💬 리뷰 포인트
> 마커 불러오기 API - 응답코드 404 -> 204, 검색 API - 응답 수정(무한스크롤 추가)
## 🚀 상세 설명
1. 마커 불러오기 API에서 데이터가 없을 경우 기존은 404 응답코드를 내보냈었지만
204로 수정하여 API 응답 통일화를 하였습니다.( 응답코드가 아직 다른 몇몇 API 들도 추가 수정 예정)
2. 검색 API의 경우 응답 중 아파트 주소 및 무한 스크롤 적용을 위한 페이지네이션 코드를 추가하였습니다
## 📸 스크린샷
응답코드 204 - 404
<img width="612" alt="image" src="https://github.com/user-attachments/assets/28ebea5d-7fa5-4f2b-9f6e-3fdd69e55460" />

무한스크롤 적용
<img width="582" alt="image" src="https://github.com/user-attachments/assets/a00dea05-d75f-4f54-b006-9db863af790a" />


## 📢 노트