### PR TITLE
Fix[#9]: 중복 뉴스 처리 로직 개선 및 pubDate 필드 추가

### DIFF
--- a/src/main/java/com/myapt/domain/news/dto/NewsCrawlingResponse.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsCrawlingResponse.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.OffsetDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -13,6 +15,7 @@ public class NewsCrawlingResponse {
 	private String link;
 	private String description;
 	private String imageLink;
+	private OffsetDateTime pubDate;
 
 	public boolean validateImageLink() {
 		return imageLink != null && !imageLink.isEmpty();

--- a/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
@@ -1,5 +1,6 @@
 package com.myapt.domain.news.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.jsoup.nodes.Document;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -7,6 +8,8 @@ import com.myapt.domain.news.util.JsoupCrawling;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.OffsetDateTime;
 
 @Getter
 @Slf4j
@@ -18,6 +21,9 @@ public class NewsSummaryDto {
 	private String link;
 	@JsonSetter("description")
 	private String description;
+	@JsonSetter("pubDate")
+	@JsonFormat(pattern = "EEE, dd MMM yyyy HH:mm:ss Z", locale = "en")
+	private OffsetDateTime pubDate;
 
 	/*
 		뉴스 링크를 통해 HTML 문서를 가져와 크롤링을 수행하고
@@ -37,6 +43,7 @@ public class NewsSummaryDto {
 				.title(title)
 				.link(link)
 				.description(description)
+				.pubDate(pubDate)
 				.build();
 		}
 
@@ -55,6 +62,7 @@ public class NewsSummaryDto {
 			.title((extractedTitle != null) ? extractedTitle : title)
 			.link(link)
 			.description((extractedContent != null) ? extractedContent : description)
+			.pubDate(pubDate)
 			.build();
 	}
 }

--- a/src/main/java/com/myapt/domain/news/entity/News.java
+++ b/src/main/java/com/myapt/domain/news/entity/News.java
@@ -1,6 +1,7 @@
 package com.myapt.domain.news.entity;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,6 +33,8 @@ public class News {
 
 	private String url; // 뉴스 url
 
+	private OffsetDateTime pubDate; // 뉴스 출판 날짜
+
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
@@ -41,7 +44,7 @@ public class News {
 	//기타
 	@Builder
 	private News(String type, String platform, String image, String title, String content, String url,
-		LocalDateTime createdAt, LocalDateTime updatedAt) {
+		LocalDateTime createdAt, LocalDateTime updatedAt, OffsetDateTime pubDate) {
 		this.type = type;
 		this.platform = platform;
 		this.image = image;
@@ -50,6 +53,7 @@ public class News {
 		this.url = url;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
+		this.pubDate = pubDate;
 	}
 
 	public LocalDateTime getCreateAt() {

--- a/src/main/java/com/myapt/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/myapt/domain/news/repository/NewsRepository.java
@@ -13,5 +13,5 @@ import com.myapt.domain.news.entity.News;
 public interface NewsRepository extends JpaRepository<News, Long> {
 	Page<News> findAllByType(Pageable pageable, String type);
 
-	Optional<News> findFirstByTypeOrderByIdDesc(String type);
+	Optional<News> findFirstByTypeOrderByPubDateDesc(String type);
 }

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -66,7 +65,7 @@ public class NewsServiceImpl implements NewsService {
 	private void processDefectNews() {
 		String defectKeyword = "아파트 부실 시공 공사";
 
-		// 부실 뉴스 조회
+		// 부실 뉴스 조회 - 가장 최근 뉴스가 첫번째, 가장 오래된 뉴스가 마지막
 		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
 			.orElseThrow(NewsNullException::new);
 		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoList();
@@ -127,19 +126,16 @@ public class NewsServiceImpl implements NewsService {
 	 */
 	private List<NewsCrawlingResponse> filterDuplicateNewsInDB(List<NewsCrawlingResponse> newsList, String newsType) {
 		// DB에 저장된 같은 타입의 뉴스 중에서 가장 최근 뉴스의 URL 가져온다
-		Optional<News> lastNewsOpt = newsRepository.findFirstByTypeOrderByIdDesc(newsType);
+		Optional<News> lastNewsOpt = newsRepository.findFirstByTypeOrderByPubDateDesc(newsType);
 		if (lastNewsOpt.isEmpty()) {
 			return newsList;
 		}
 		String lastNewsUrl = lastNewsOpt.get().getUrl();
 
 		// 뉴스 리스트에서 DB에 저장된 최신 뉴스(및 그 이전 뉴스)는 제거
-		int duplicateNewsIndex = IntStream.range(0, newsList.size())
-			.filter(i -> newsList.get(i).getLink().equals(lastNewsUrl))
-			.findFirst()
-			.orElse(-1);
-
-		return newsList.subList(duplicateNewsIndex + 1, newsList.size());
+		return newsList.stream()
+				.takeWhile(news -> !news.getLink().equals(lastNewsUrl))
+				.toList();
 	}
 
 	/*
@@ -196,6 +192,7 @@ public class NewsServiceImpl implements NewsService {
 			.url(dto.getLink())
 			.createdAt(LocalDateTime.now())
 			.updatedAt(LocalDateTime.now())
+			.pubDate(dto.getPubDate())
 			.build();
 	}
 


### PR DESCRIPTION
## 📌 이슈 번호
> #9 

## 💬 리뷰 포인트
- 이번에 수정한 중복 뉴스를 처리하는 로직 부분을 확인해주세요.
- News 엔티티에 pubDate 필드 추가로 인한 영향이 있는지 확인해주세요.

## 🚀 상세 설명
- 문제 상황
    1. DB에서 ID 기준으로 오름차순 정렬했을 때 마지막 뉴스가 최신 뉴스라고 가정했으나, 저장되는 요소들의 순서에 따라서 마지막 뉴스가 최신 뉴스가 아닐 수 있음.
    2. 뉴스 검색 API 응답은 최신순으로 정렬되어 있는데, 첫번째 뉴스가 가장 최신 뉴스임에도 불구하고 이를 가장 오래된 뉴스라고 오해하여 중복 뉴스 기준으로 오래된 뉴스만 저장하는 문제가 발생함.

- 해결 방안:
   1. 뉴스 엔티티에 pubDate 필드를 추가하여 DB에 저장된 뉴스 중 pubDate를 기준으로 가장 최신 뉴스를 가져옴
   2. API 뉴스 리스트를 순회할 때, DB에 저장된 최신 뉴스와 url 기준으로 중복인 뉴스가 등장하면 그 이후의 뉴스는 다 중복된다고 판단하여 모두 제외하고, 중복 뉴스가 나타나기 전까지의 최신 뉴스만 DB에 저장하도록 수정.  

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/f9b10bf4-345d-42ad-9d43-70a9a404f649)
![image](https://github.com/user-attachments/assets/f271a903-0aa9-41a7-a0ee-7c7dd4898901)

## 📢 노트
