### PR TITLE
[FEAT] 지도좌표 API Response 주소 추가 관련

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/MapMarkerInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MapMarkerInfo.java
@@ -6,13 +6,15 @@ import lombok.Builder;
 public record MapMarkerInfo(
 	String aptId,
 	String aptName,
+	String aptAddress,
 	Double latitude,
 	Double longitude
 ) {
-	public static MapMarkerInfo of(String aptId, String aptName, Double latitude, Double longitude) {
+	public static MapMarkerInfo of(String aptId, String aptName, String aptAddress, Double latitude, Double longitude) {
 		return MapMarkerInfo.builder()
 			.aptId(aptId)
 			.aptName(aptName)
+			.aptAddress(aptAddress)
 			.latitude(latitude)
 			.longitude(longitude)
 			.build();

--- a/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/MapServiceImpl.java
@@ -32,6 +32,7 @@ public class MapServiceImpl implements MapService {
 				.map(building -> MapMarkerInfo.of(
 					building.getId(),
 					building.getAptNm(),
+					building.getRdnmadr(),
 					building.getLa(),
 					building.getLo()))
 				.collect(Collectors.toList());
@@ -41,6 +42,7 @@ public class MapServiceImpl implements MapService {
 				.map(building -> MapMarkerInfo.of(
 					building.getId(),
 					building.getAptNm(),
+					building.getRdnmadr(),
 					building.getLa(),
 					building.getLo()))
 				.collect(Collectors.toList());


### PR DESCRIPTION
## 📌 이슈 번호
> #58 

## 💬 리뷰 포인트
> 지도 좌표 불러오기 API Response 변경 -> aptAddress 추가

## 🚀 상세 설명
지도 좌표 불러오기 API에서 디자인 변경에 따라
프론트에서 응답에 aptAddress 속성도 요청하여 추가하였습니다.

- 바뀐 응답
```
  "status": 200,
  "message": "공지사항 3개씩 로딩완료",
  "data": [
	    {
          "aptId": "A000121110"
          "aptName": "개포좋은집",
          "aptAddress": "개포동 164-1",
          "latitude": 37.4836153766895,
          "longitude": 127.060774201139
      } ...
  ]
```

## 📸 스크린샷
<img width="476" alt="image" src="https://github.com/user-attachments/assets/6c5ed044-9556-4816-ae81-45b3c646e920" />


## 📢 노트