### PR TITLE
Feat/apt #62

### DIFF
--- a/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfo.java
@@ -4,31 +4,25 @@ import lombok.Builder;
 
 import java.util.List;
 
-@Builder
-// 아파트 기본 정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfo(
-        AptBasicInfo aptInfo, // 아파트 기본 정보
-        BuildInfo buildInfo, // 건물 기본 정보
-        //List<SellingPrice> sellingPrice, // 매매가 정보
-        MonthlyMaintenanceFees monthlyMaintenanceFees, // 월별 관리비
-        EtcInfo etcInfo // 기타 정보
+        AptBasicInfo aptInfo,
+        BuildInfo buildInfo,
+        MonthlyMaintenanceFees monthlyMaintenanceFees,
+        EtcInfo etcInfo
 ) {
-    // of 메서드는 인자를 받아 AptInfo 객체를 생성하는데, 이는 DTO 객체를 생성하여 클라이언트로 반환할 때 유용합니다.
     @Builder
     public static AptInfo of(
             String detailId, String name, String roadAddress, String zipCode,
-            String completionDate, String developer, String constructor, long numberOfUnits,
-            //List<SellingPrice> sellingPrice,
+            String completionDate, String developer, String constructor, Long numberOfUnits,
             String year, List<MonthlyMaintenanceData> monthlyMaintenanceData,
             List<String> amenities, String buildingStructure, String managementType, String heatingType,
-            long cctvCount, long totalParkingSpaces, long totalGroundEvChargerCount,
+            Long cctvCount, Long totalParkingSpaces, Long totalGroundEvChargerCount,
             String managementOfficeAddress, String managementOfficeContact, String managementOfficeFax,
             String housingManager
     ) {
         return new AptInfo(
                 new AptBasicInfo(detailId, name, roadAddress, zipCode),
                 new BuildInfo(completionDate, developer, constructor, numberOfUnits),
-                //sellingPrice,
                 new MonthlyMaintenanceFees(year, monthlyMaintenanceData),
                 new EtcInfo(amenities, buildingStructure, managementType, heatingType, cctvCount, totalParkingSpaces,
                         totalGroundEvChargerCount, managementOfficeAddress, managementOfficeContact,
@@ -36,26 +30,14 @@ public record AptInfo(
         );
     }
 
-    // 아파트 기본 정보를 나타내는 클래스입니다.
     public record AptBasicInfo(String detailId, String name, String roadAddress, String zipCode) {}
-
-    // 건물 기본 정보를 나타내는 클래스입니다.
-    public record BuildInfo(String completionDate, String developer, String constructor, long numberOfUnits) {}
-
-    // 매매가 정보를 나타내는 클래스입니다.
-    //public record SellingPrice(long netArea, long price) {}
-
-    // 월별 관리비 정보를 나타내는 클래스입니다.
+    public record BuildInfo(String completionDate, String developer, String constructor, Long numberOfUnits) {}
     public record MonthlyMaintenanceFees(String year, List<MonthlyMaintenanceData> data) {}
-
-    // 월별 관리비 데이터 정보를 나타내는 클래스입니다.
-    public record MonthlyMaintenanceData(String month, long fee) {}
-
-    // 기타 정보를 나타내는 클래스입니다.
+    public record MonthlyMaintenanceData(String month, Long fee) {}
     public record EtcInfo(
             List<String> amenities, String buildingStructure, String managementType, String heatingType,
-            long cctvCount, long totalParkingSpaces, long totalGroundEvChargerCount,
+            Long cctvCount, Long totalParkingSpaces, Long totalGroundEvChargerCount,
             String managementOfficeAddress, String managementOfficeContact, String managementOfficeFax,
             String housingManager
-    ) {}
+    ){}
 }

--- a/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
+++ b/src/main/java/com/myapt/domain/apt/dto/AptInfoDetail.java
@@ -17,64 +17,81 @@ import java.util.List;
 })
 // 아파트의 상세정보를 반환할 때 사용되는 DTO 클래스입니다.
 public record AptInfoDetail(
-    Building building, // 건물 정보
-    AccessibleToPublic accessibleToPublic, // 외부인 개방 여부 정보
-    Parking parking, // 주차 정보
-    EvCharging evCharging, // 전기차 충전 정보
-    DisinfectionManagement disinfectionManagement, // 소독 관리 정보
-    SecurityManagement securityManagement, // 경비 관리 정보
-    CleaningManagement cleaningManagement, // 청소 관리 정보
-    GeneralManagement generalManagement // 일반 관리 정보
+        Building building, // 건물 정보
+        AccessibleToPublic accessibleToPublic, // 외부인 개방 여부 정보
+        Parking parking, // 주차 정보
+        EvCharging evCharging, // 전기차 충전 정보
+        DisinfectionManagement disinfectionManagement, // 소독 관리 정보
+        SecurityManagement securityManagement, // 경비 관리 정보
+        CleaningManagement cleaningManagement, // 청소 관리 정보
+        GeneralManagement generalManagement // 일반 관리 정보
 ) {
     // of 메서드는 인자를 받아 AptInfoDetail 객체를 생성하는데, 이는 DTO 객체를 생성하여 클라이언트로 반환할 때 유용합니다.
     @Builder
     public static AptInfoDetail of(
-        long maxFloorCount, long basementFloorCount, long passengerCargoElevatorCount, String buildingStructure,
-        boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic,
-        long groundParkingSpaces, long undergroundParkingSpaces,
-        long groundEvChargerCount, long undergroundEvChargerCount, long groundEvParkingSpaces,
-        long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails,
-        String disinfectionManagementType, String disinfectionManagementContractor, long annualDisinfectionFrequency,
-        String securityManagementType, String securityManagementContractor, long securityManagementStaff,
-        String cleaningManagementType, String cleaningManagementContractor, String foodWasteDisposalMethod,
-        long generalManagementStaff
+            Long maxFloorCount, Long basementFloorCount, Long passengerCargoElevatorCount, String buildingStructure,
+            Boolean groundAccessibleToPublic, Boolean undergroundAccessibleToPublic,
+            Long groundParkingSpaces, Long undergroundParkingSpaces,
+            Long groundEvChargerCount, Long undergroundEvChargerCount, Long groundEvParkingSpaces,
+            Long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails,
+            String disinfectionManagementType, String disinfectionManagementContractor, Long annualDisinfectionFrequency,
+            String securityManagementType, String securityManagementContractor, Long securityManagementStaff,
+            String cleaningManagementType, String cleaningManagementContractor, String foodWasteDisposalMethod,
+            Long generalManagementStaff
     ) {
         return new AptInfoDetail(
-            new Building(maxFloorCount, basementFloorCount, passengerCargoElevatorCount, buildingStructure),
-            new AccessibleToPublic(groundAccessibleToPublic, undergroundAccessibleToPublic),
-            new Parking(groundParkingSpaces, undergroundParkingSpaces),
-            new EvCharging(groundEvChargerCount, undergroundEvChargerCount, groundEvParkingSpaces, undergroundEvParkingSpaces, evChargingFacilitiesDetails),
-            new DisinfectionManagement(disinfectionManagementType, disinfectionManagementContractor, annualDisinfectionFrequency),
-            new SecurityManagement(securityManagementType, securityManagementContractor, securityManagementStaff),
-            new CleaningManagement(cleaningManagementType, cleaningManagementContractor, foodWasteDisposalMethod),
-            new GeneralManagement(generalManagementStaff)
+                maxFloorCount != null || basementFloorCount != null || passengerCargoElevatorCount != null || buildingStructure != null
+                        ? new Building(maxFloorCount, basementFloorCount, passengerCargoElevatorCount, buildingStructure)
+                        : null,
+                groundAccessibleToPublic != null || undergroundAccessibleToPublic != null
+                        ? new AccessibleToPublic(groundAccessibleToPublic, undergroundAccessibleToPublic)
+                        : null,
+                groundParkingSpaces != null || undergroundParkingSpaces != null
+                        ? new Parking(groundParkingSpaces, undergroundParkingSpaces)
+                        : null,
+                groundEvChargerCount != null || undergroundEvChargerCount != null || groundEvParkingSpaces != null ||
+                        undergroundEvParkingSpaces != null || (evChargingFacilitiesDetails != null && !evChargingFacilitiesDetails.isEmpty())
+                        ? new EvCharging(groundEvChargerCount, undergroundEvChargerCount, groundEvParkingSpaces, undergroundEvParkingSpaces, evChargingFacilitiesDetails)
+                        : null,
+                disinfectionManagementType != null || disinfectionManagementContractor != null || annualDisinfectionFrequency != null
+                        ? new DisinfectionManagement(disinfectionManagementType, disinfectionManagementContractor, annualDisinfectionFrequency)
+                        : null,
+                securityManagementType != null || securityManagementContractor != null || securityManagementStaff != null
+                        ? new SecurityManagement(securityManagementType, securityManagementContractor, securityManagementStaff)
+                        : null,
+                cleaningManagementType != null || cleaningManagementContractor != null || foodWasteDisposalMethod != null
+                        ? new CleaningManagement(cleaningManagementType, cleaningManagementContractor, foodWasteDisposalMethod)
+                        : null,
+                generalManagementStaff != null
+                        ? new GeneralManagement(generalManagementStaff)
+                        : null
         );
     }
 
     // 건물 정보를 나타내는 클래스입니다.
-    public record Building(long maxFloorCount, long basementFloorCount, long passengerCargoElevatorCount, String buildingStructure) {}
+    public record Building(Long maxFloorCount, Long basementFloorCount, Long passengerCargoElevatorCount, String buildingStructure) {}
 
     // 외부인 개방 여부 정보를 나타내는 클래스입니다.
-    public record AccessibleToPublic(boolean groundAccessibleToPublic, boolean undergroundAccessibleToPublic) {}
+    public record AccessibleToPublic(Boolean groundAccessibleToPublic, Boolean undergroundAccessibleToPublic) {}
 
     // 주차 정보를 나타내는 클래스입니다.
-    public record Parking(long groundParkingSpaces, long undergroundParkingSpaces) {}
+    public record Parking(Long groundParkingSpaces, Long undergroundParkingSpaces) {}
 
     // 전기차 충전 정보를 나타내는 클래스입니다.
-    public record EvCharging(long groundEvChargerCount, long undergroundEvChargerCount, long groundEvParkingSpaces, long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails) {}
+    public record EvCharging(Long groundEvChargerCount, Long undergroundEvChargerCount, Long groundEvParkingSpaces, Long undergroundEvParkingSpaces, List<EvChargingFacilityDetail> evChargingFacilitiesDetails) {}
 
     // 전기차 충전 시설 상세 정보를 나타내는 클래스입니다.
-    public record EvChargingFacilityDetail(String location, String type, String connector, String chargingSpeed, long count, String provider) {}
+    public record EvChargingFacilityDetail(String location, String type, String connector, String chargingSpeed, Long count, String provider) {}
 
     // 소독 관리 정보를 나타내는 클래스입니다.
-    public record DisinfectionManagement(String managementType, String contractor, long annualFrequency) {}
+    public record DisinfectionManagement(String managementType, String contractor, Long annualFrequency) {}
 
     // 경비 관리 정보를 나타내는 클래스입니다.
-    public record SecurityManagement(String managementType, String contractor, long staffCount) {}
+    public record SecurityManagement(String managementType, String contractor, Long staffCount) {}
 
     // 청소 관리 정보를 나타내는 클래스입니다.
     public record CleaningManagement(String managementType, String contractor, String foodWasteDisposalMethod) {}
 
     // 일반 관리 정보를 나타내는 클래스입니다.
-    public record GeneralManagement(long staffCount) {}
+    public record GeneralManagement(Long staffCount) {}
 }

--- a/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
+++ b/src/main/java/com/myapt/domain/apt/dto/MngCostInfo.java
@@ -11,11 +11,10 @@ public record MngCostInfo(
         List<MonthlyFee> totalCommonManagementFeeSum,// 공용관리비 월별 데이터
         List<MonthlyFee> reserveFundMonthlyCharge    // 장충금 월 부과액
 ) {
-
     @Builder
     public static record MonthlyFee(
             String month, // 월
-            long fee      // 비용
+            Long fee      // 비용
     ) {
     }
 }

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -5,7 +5,6 @@ import com.myapt.domain.apt.entity.*;
 import com.myapt.domain.apt.exception.NoticeNotFoundException;
 import com.myapt.domain.apt.repository.*;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -94,6 +93,7 @@ public class AptServiceImpl implements AptService{
         return NoticeResponse.of(noticeInfoList, noticeRepository.count());
     }
 
+    // 아파트 기본 정보 조회
     @Override
     public AptInfo getApartmentInfo(String aptsId) {
         // #1. apts_id를 사용해서, Apts와 DetailApts의 리포지토리들로부터 아파트 기본 정보를 받아온다.
@@ -102,78 +102,105 @@ public class AptServiceImpl implements AptService{
         DetailApts detailApts = optionalDetailApts.orElse(new DetailApts()); // 기본값을 가지는 새로운 객체 생성
 
         // #2. detail_apts_id(아파트 관리비 코드)에 해당하는 월별 관리비를 계산 및 나머지 요소들과 함께 아파트 기본정보를 반환하는 코드
-        List<MngCost> mngCosts = defaultIfNull(mngCostRepository.findByDetailAptsId(detailApts.getId()), Collections.emptyList());
+        List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailApts.getId());
 
-        // #3. 세대수 가져오기
-        long numberOfUnits = defaultIfNull(detailApts.getNumberOfUnits(), 0).longValue();
+        // #3. 세대수 가져오기 (0이면 null로 처리)
+        Long numberOfUnits = (detailApts.getNumberOfUnits() == null || detailApts.getNumberOfUnits() == 0L)
+                ? null : detailApts.getNumberOfUnits();
 
         // #4. 월별 관리비 계산 (세대수 이용)
-        List<AptInfo.MonthlyMaintenanceData> monthlyMaintenanceData = mngCosts.stream()
+        List<AptInfo.MonthlyMaintenanceData> monthlyMaintenanceData = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
 
-                    long fee = (defaultIfNull(mngCost.getIndividualUsageSum(), 0L) / numberOfUnits) +
-                            (defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L) / numberOfUnits) +
-                            (defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L) / numberOfUnits);
+                    Long fee = (numberOfUnits != null && numberOfUnits > 0)
+                            ? (mngCost.getIndividualUsageSum() != null && mngCost.getIndividualUsageSum() > 0 ? mngCost.getIndividualUsageSum() / numberOfUnits : 0L) +
+                            (mngCost.getReserveFundMonthlyCharge() != null && mngCost.getReserveFundMonthlyCharge() > 0 ? mngCost.getReserveFundMonthlyCharge() / numberOfUnits : 0L) +
+                            (mngCost.getTotalCommonManagementFeeSum() != null && mngCost.getTotalCommonManagementFeeSum() > 0 ? mngCost.getTotalCommonManagementFeeSum() / numberOfUnits : 0L)
+                            : null;
 
-                    return new AptInfo.MonthlyMaintenanceData(month, fee);
+                    // 계산된 fee가 0이면 null로 처리
+                    return new AptInfo.MonthlyMaintenanceData(month, fee == null || fee == 0L ? null : fee);
                 })
+                .sorted(Comparator.comparing(AptInfo.MonthlyMaintenanceData::month)) // 월별 정렬
                 .collect(Collectors.toList());
-        // #4-2. 월별 관리비 데이터를 월(month) 기준으로 정렬
-        monthlyMaintenanceData.sort(Comparator.comparing(AptInfo.MonthlyMaintenanceData::month));
+        // 리스트가 비어있거나 모든 값이 null이면 null로 처리
+        monthlyMaintenanceData = (monthlyMaintenanceData == null || monthlyMaintenanceData.stream().allMatch(d -> d.fee() == null)) ? null : monthlyMaintenanceData;
 
         // #5. 연도 정보 추출 (첫 번째 관리비 기록의 연도 사용)
-        String year = mngCosts.stream()
+        String year = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.stream()
                 .findFirst()
                 .map(mngCost -> String.valueOf(mngCost.getOccurrenceYearMonth()).substring(0, 4))
-                .orElse("연도 정보 없음");
+                .filter(y -> !y.isEmpty()) // 빈 문자열 체크
+                .orElse(null);
 
         // #6. amenities 문자열을 List<String>으로 변환
-        List<String> amenitiesList = Arrays.stream(defaultIfNull(detailApts.getAmenities(), "").split(","))
+        List<String> amenitiesList = (detailApts.getAmenities() == null || detailApts.getAmenities().isEmpty() || detailApts.getAmenities().trim().isEmpty())
+                ? null
+                : Arrays.stream(detailApts.getAmenities().split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
 
         // #7. 총 전기차 충전기 대수 계산
-        long totalGroundEvChargerCount = defaultIfNull(detailApts.getGroundEvChargerCount(), 0).longValue() +
-                defaultIfNull(detailApts.getUndergroundEvChargerCount(), 0).longValue();
+        Long totalGroundEvChargerCount = (detailApts.getGroundEvChargerCount() == null && detailApts.getUndergroundEvChargerCount() == null)
+                ? null
+                : ((detailApts.getGroundEvChargerCount() != null && detailApts.getGroundEvChargerCount() > 0 ? detailApts.getGroundEvChargerCount() : 0L) +
+                (detailApts.getUndergroundEvChargerCount() != null && detailApts.getUndergroundEvChargerCount() > 0 ? detailApts.getUndergroundEvChargerCount() : 0L));
+        totalGroundEvChargerCount = (totalGroundEvChargerCount == null || totalGroundEvChargerCount == 0L) ? null : totalGroundEvChargerCount;
 
-        // #8. 매매가 정보를 가져와서 SellingPrice 객체 리스트로 변환
-//        List<AptInfo.SellingPrice> sellingPrices = Optional.ofNullable(detailApts.getSellingPrice())
-//                .orElse(Collections.emptyList())
-//                .stream()
-//                .map(sp -> new AptInfo.SellingPrice(sp.getNetArea(), sp.getPrice()))
-//                .collect(Collectors.toList());
+        // #8. completionDate 처리 (Integer 타입 가정)
+        String completionDate = (apts.getUseAprvYear() == null || apts.getUseAprvYear() == 0)
+                ? null : String.valueOf(apts.getUseAprvYear());
 
         // #9. AptInfo DTO 객체를 생성해서 모든 정보를 담는다.
+        // null, 0, 빈 문자열 체크 추가
+        String aptNm = (apts.getAptNm() == null || apts.getAptNm().trim().isEmpty()) ? null : apts.getAptNm();
+        String rdnmadr = (apts.getRdnmadr() == null || apts.getRdnmadr().trim().isEmpty()) ? null : apts.getRdnmadr();
+        String postalCode = (detailApts.getPostalCode() == null || detailApts.getPostalCode().trim().isEmpty()) ? null : detailApts.getPostalCode();
+        String developer = (detailApts.getDeveloper() == null || detailApts.getDeveloper().trim().isEmpty()) ? null : detailApts.getDeveloper();
+        String constructor = (detailApts.getConstructor() == null || detailApts.getConstructor().trim().isEmpty()) ? null : detailApts.getConstructor();
+        String buldStru = (apts.getBuldStru() == null || apts.getBuldStru().trim().isEmpty()) ? null : apts.getBuldStru();
+        String managementType = (detailApts.getManagementType() == null || detailApts.getManagementType().trim().isEmpty()) ? null : detailApts.getManagementType();
+        String heatingType = (detailApts.getHeatingType() == null || detailApts.getHeatingType().trim().isEmpty()) ? null : detailApts.getHeatingType();
+        Long cctvCount = (detailApts.getCctvCount() == null || detailApts.getCctvCount() == 0L) ? null : detailApts.getCctvCount();
+        Long totalParkingSpaces = (detailApts.getTotalParkingSpaces() == null || detailApts.getTotalParkingSpaces() == 0L) ? null : detailApts.getTotalParkingSpaces();
+        String managementOfficeAddress = (detailApts.getManagementOfficeAddress() == null || detailApts.getManagementOfficeAddress().trim().isEmpty()) ? null : detailApts.getManagementOfficeAddress();
+        String managementOfficeContact = (detailApts.getManagementOfficeContact() == null || detailApts.getManagementOfficeContact().trim().isEmpty()) ? null : detailApts.getManagementOfficeContact();
+        String managementOfficeFax = (detailApts.getManagementOfficeFax() == null || detailApts.getManagementOfficeFax().trim().isEmpty()) ? null : detailApts.getManagementOfficeFax();
+        String housingManager = (detailApts.getHousingManager() == null || detailApts.getHousingManager().trim().isEmpty()) ? null : detailApts.getHousingManager();
+
         return AptInfo.of(
-                defaultIfNull(detailApts.getId(), ""),
-                defaultIfNull(apts.getAptNm(), ""),
-                defaultIfNull(apts.getRdnmadr(), ""),
-                defaultIfNull(detailApts.getPostalCode(), ""),
-                defaultIfNull(String.valueOf(apts.getUseAprvYear()), "0"),
-                defaultIfNull(detailApts.getDeveloper(), ""),
-                defaultIfNull(detailApts.getConstructor(), ""),
+                detailApts.getId(),
+                aptNm,
+                rdnmadr,
+                postalCode,
+                completionDate,
+                developer,
+                constructor,
                 numberOfUnits,
-                //sellingPrices, // 매매가 정보 추가
-                year, // 연도 정보 추가
+                year,
                 monthlyMaintenanceData,
                 amenitiesList,
-                defaultIfNull(apts.getBuldStru(), ""),
-                defaultIfNull(detailApts.getManagementType(), ""),
-                defaultIfNull(detailApts.getHeatingType(), ""),
-                defaultIfNull(detailApts.getCctvCount(), 0).longValue(),
-                defaultIfNull(detailApts.getTotalParkingSpaces(), 0).longValue(),
+                buldStru,
+                managementType,
+                heatingType,
+                cctvCount,
+                totalParkingSpaces,
                 totalGroundEvChargerCount,
-                defaultIfNull(detailApts.getManagementOfficeAddress(), ""),
-                defaultIfNull(detailApts.getManagementOfficeContact(), ""),
-                defaultIfNull(detailApts.getManagementOfficeFax(), ""),
-                defaultIfNull(detailApts.getHousingManager(), "")
+                managementOfficeAddress,
+                managementOfficeContact,
+                managementOfficeFax,
+                housingManager
         );
     }
 
-
+    // 아파트 정보 상세조회
     @Override
     public AptInfoDetail getApartmentInfoDetail(String detailAptsId) {
         // #1. detailAptsId 를 사용해서 DetailApts의 리포지토리로부터 아파트 상세정보들을 받아온다.
@@ -181,45 +208,53 @@ public class AptServiceImpl implements AptService{
                 .orElseThrow(() -> new RuntimeException("해당 아파트 상세정보가 서버에 존재하지 않습니다."));
 
         // 전기차 충전 시설 상세 정보를 문자열로 받아옵니다.
-        String evChargingDetailsString = detailApts.getEvChargingFacilitiesDetails();
+        String evChargingDetailsString = (detailApts.getEvChargingFacilitiesDetails() == null || detailApts.getEvChargingFacilitiesDetails().trim().isEmpty())
+                ? null : detailApts.getEvChargingFacilitiesDetails();
         // 문자열을 파싱하여 리스트를 채웁니다.
-        List<AptInfoDetail.EvChargingFacilityDetail> evChargingFacilitiesDetails = parseEvChargingDetails(
-                evChargingDetailsString != null ? evChargingDetailsString : "");
+        List<AptInfoDetail.EvChargingFacilityDetail> evChargingFacilitiesDetails = parseEvChargingDetails(evChargingDetailsString);
 
         // #2. AptInfoDetail DTO 객체를 생성해서 모든 정보를 담는다.
+        // null, 0, 빈 문자열 체크 추가
+        Long maxFloorCount = (detailApts.getMaxFloorCount() == null || detailApts.getMaxFloorCount() == 0L) ? null : detailApts.getMaxFloorCount();
+        Long basementFloorCount = (detailApts.getBasementFloorCount() == null || detailApts.getBasementFloorCount() == 0L) ? null : detailApts.getBasementFloorCount();
+        Long passengerCargoElevatorCount = (detailApts.getPassengerCargoElevatorCount() == null || detailApts.getPassengerCargoElevatorCount() == 0L) ? null : detailApts.getPassengerCargoElevatorCount();
+        String buildingStructure = (detailApts.getBuildingStructure() == null || detailApts.getBuildingStructure().trim().isEmpty()) ? null : detailApts.getBuildingStructure();
+        Boolean groundAccessibleToPublic = detailApts.getGroundAccessibleToPublic(); // Boolean은 0이 없으므로 그대로 유지
+        Boolean undergroundAccessibleToPublic = detailApts.getUndergroundAccessibleToPublic();
+        Long groundParkingSpaces = (detailApts.getGroundParkingSpaces() == null || detailApts.getGroundParkingSpaces() == 0L) ? null : detailApts.getGroundParkingSpaces();
+        Long undergroundParkingSpaces = (detailApts.getUndergroundParkingSpaces() == null || detailApts.getUndergroundParkingSpaces() == 0L) ? null : detailApts.getUndergroundParkingSpaces();
+        Long groundEvChargerCount = (detailApts.getGroundEvChargerCount() == null || detailApts.getGroundEvChargerCount() == 0L) ? null : detailApts.getGroundEvChargerCount();
+        Long undergroundEvChargerCount = (detailApts.getUndergroundEvChargerCount() == null || detailApts.getUndergroundEvChargerCount() == 0L) ? null : detailApts.getUndergroundEvChargerCount();
+        Long groundEvParkingSpaces = (detailApts.getGroundEvParkingSpaces() == null || detailApts.getGroundEvParkingSpaces() == 0L) ? null : detailApts.getGroundEvParkingSpaces();
+        Long undergroundEvParkingSpaces = (detailApts.getUndergroundEvParkingSpaces() == null || detailApts.getUndergroundEvParkingSpaces() == 0L) ? null : detailApts.getUndergroundEvParkingSpaces();
+        String disinfectionManagementType = (detailApts.getDisinfectionManagementType() == null || detailApts.getDisinfectionManagementType().trim().isEmpty()) ? null : detailApts.getDisinfectionManagementType();
+        String disinfectionManagementContractor = (detailApts.getDisinfectionManagementContractor() == null || detailApts.getDisinfectionManagementContractor().trim().isEmpty()) ? null : detailApts.getDisinfectionManagementContractor();
+        Long annualDisinfectionFrequency = (detailApts.getAnnualDisinfectionFrequency() == null || detailApts.getAnnualDisinfectionFrequency() == 0L) ? null : detailApts.getAnnualDisinfectionFrequency();
+        String securityManagementType = (detailApts.getSecurityManagementType() == null || detailApts.getSecurityManagementType().trim().isEmpty()) ? null : detailApts.getSecurityManagementType();
+        String securityManagementContractor = (detailApts.getSecurityManagementContractor() == null || detailApts.getSecurityManagementContractor().trim().isEmpty()) ? null : detailApts.getSecurityManagementContractor();
+        Long securityManagementStaff = (detailApts.getSecurityManagementStaff() == null || detailApts.getSecurityManagementStaff() == 0L) ? null : detailApts.getSecurityManagementStaff();
+        String cleaningManagementType = (detailApts.getCleaningManagementType() == null || detailApts.getCleaningManagementType().trim().isEmpty()) ? null : detailApts.getCleaningManagementType();
+        String cleaningManagementContractor = (detailApts.getCleaningManagementContractor() == null || detailApts.getCleaningManagementContractor().trim().isEmpty()) ? null : detailApts.getCleaningManagementContractor();
+        String foodWasteDisposalMethod = (detailApts.getFoodWasteDisposalMethod() == null || detailApts.getFoodWasteDisposalMethod().trim().isEmpty()) ? null : detailApts.getFoodWasteDisposalMethod();
+        Long generalManagementStaff = (detailApts.getGeneralManagementStaff() == null || detailApts.getGeneralManagementStaff() == 0L) ? null : detailApts.getGeneralManagementStaff();
+
         return AptInfoDetail.of(
-                defaultIfNull(detailApts.getMaxFloorCount(), 0L),
-                defaultIfNull(detailApts.getBasementFloorCount(), 0L),
-                defaultIfNull(detailApts.getPassengerCargoElevatorCount(), 0L),
-                defaultIfNull(detailApts.getBuildingStructure(), ""),
-                defaultIfNull(detailApts.getGroundAccessibleToPublic(), false), // 외부인 개방 여부(지상) 추가
-                defaultIfNull(detailApts.getUndergroundAccessibleToPublic(), false), // 외부인 개방 여부(지하) 추가
-                defaultIfNull(detailApts.getGroundParkingSpaces(), 0L),
-                defaultIfNull(detailApts.getUndergroundParkingSpaces(), 0L),
-                defaultIfNull(detailApts.getGroundEvChargerCount(), 0L),
-                defaultIfNull(detailApts.getUndergroundEvChargerCount(), 0L),
-                defaultIfNull(detailApts.getGroundEvParkingSpaces(), 0L),
-                defaultIfNull(detailApts.getUndergroundEvParkingSpaces(), 0L),
-                evChargingFacilitiesDetails,
-                defaultIfNull(detailApts.getDisinfectionManagementType(), ""),
-                defaultIfNull(detailApts.getDisinfectionManagementContractor(), ""),
-                defaultIfNull(detailApts.getAnnualDisinfectionFrequency(), 0L),
-                defaultIfNull(detailApts.getSecurityManagementType(), ""),
-                defaultIfNull(detailApts.getSecurityManagementContractor(), ""),
-                defaultIfNull(detailApts.getSecurityManagementStaff(), 0L),
-                defaultIfNull(detailApts.getCleaningManagementType(), ""),
-                defaultIfNull(detailApts.getCleaningManagementContractor(), ""),
-                defaultIfNull(detailApts.getFoodWasteDisposalMethod(), ""),
-                defaultIfNull(detailApts.getGeneralManagementStaff(), 0L)
+                maxFloorCount, basementFloorCount, passengerCargoElevatorCount, buildingStructure,
+                groundAccessibleToPublic, undergroundAccessibleToPublic,
+                groundParkingSpaces, undergroundParkingSpaces,
+                groundEvChargerCount, undergroundEvChargerCount, groundEvParkingSpaces, undergroundEvParkingSpaces, evChargingFacilitiesDetails,
+                disinfectionManagementType, disinfectionManagementContractor, annualDisinfectionFrequency,
+                securityManagementType, securityManagementContractor, securityManagementStaff,
+                cleaningManagementType, cleaningManagementContractor, foodWasteDisposalMethod,
+                generalManagementStaff
         );
     }
-    // defaultIfNull 메소드를 사용하여 위에서 각 필드를 검사하고, null인 경우 기본 값을 반환하도록 했다.
-    private <T> T defaultIfNull(T value, T defaultValue) {
-        return value != null ? value : defaultValue;
-    }
 
-    // evChargingFacilitiesDetails 의 문자열을 파싱하는 함수
     public static List<AptInfoDetail.EvChargingFacilityDetail> parseEvChargingDetails(String data) {
+        if (data == null || data.isEmpty()) {
+            return null; // 값이 없으면 null 반환
+        }
+
         List<AptInfoDetail.EvChargingFacilityDetail> details = new ArrayList<>();
         // 데이터 항목을 구분자로 분리
         String[] items = data.split(",(?=◆)");
@@ -233,9 +268,9 @@ public class AptServiceImpl implements AptService{
                     String type = parts[1]; // 충전기 타입
                     String connector = parts[2]; // 커넥터 타입
                     String chargingSpeed = parts[3]; // 충전 속도
-                    long count = Integer.parseInt(parts[4]); // 충전기 대수
+                    Long count = Long.parseLong(parts[4]); // 충전기 대수
                     String provider = parts[5]; // 공급자
-                    // 객체 생성
+                    // 객체 생성 (count가 0이면 null 처리하지 않음, 필요 시 수정 가능)
                     AptInfoDetail.EvChargingFacilityDetail detail = new AptInfoDetail.EvChargingFacilityDetail(
                             location, type, connector, chargingSpeed, count, provider);
                     // 리스트에 추가
@@ -249,69 +284,82 @@ public class AptServiceImpl implements AptService{
                 System.err.println("Unexpected data format: " + item);
             }
         }
-        return details;
+        return details.isEmpty() ? null : details; // 리스트가 비어있으면 null 반환
     }
-    @Override // 관리비 상세조회 API
-    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
 
+    // 관리비 상세조회
+    @Override
+    public MngCostInfo getMngCostInfoDetail(String detailAptsId) {
         // #1. 지정된 아파트 ID에 대한 아파트 상세정보를 가져옵니다.
         DetailApts detailApts = detailAptsRepository.findById(detailAptsId)
                 .orElseThrow(() -> new RuntimeException("해당 아파트 상세정보가 서버에 존재하지 않습니다."));
 
         // #1-2. 세대수 가져오기
-        long numberOfUnits = defaultIfNull(detailApts.getNumberOfUnits(), 0).longValue();
+        Long numberOfUnits = (detailApts.getNumberOfUnits() == null || detailApts.getNumberOfUnits() == 0L) ? null : detailApts.getNumberOfUnits();
 
         // #2. 지정된 아파트 ID에 대한 관리비 세부 정보를 가져옵니다.
         List<MngCost> mngCosts = mngCostRepository.findByDetailAptsId(detailAptsId);
 
         // #2-2. 첫 번째 레코드의 occurrenceYearMonth에서 연도를 추출합니다.
-        String year = mngCosts.isEmpty() ? "0000" : mngCosts.get(0).getOccurrenceYearMonth().substring(0, 4);
+        String year = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.get(0).getOccurrenceYearMonth().substring(0, 4);
+        year = (year == null || year.trim().isEmpty()) ? null : year;
 
         // #2-3. 개별 사용료를 변환하고 월 기준으로 정렬합니다.
-        List<MngCostInfo.MonthlyFee> individualUsageSum = mngCosts.stream()
+        List<MngCostInfo.MonthlyFee> individualUsageSum = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
-                    long individualUsage = defaultIfNull(mngCost.getIndividualUsageSum(), 0L);
-                    return new MngCostInfo.MonthlyFee(
-                            month,
-                            numberOfUnits > 0 ? individualUsage / numberOfUnits : 0L
-                    );
+                    Long individualUsage = (numberOfUnits != null && numberOfUnits > 0 && mngCost.getIndividualUsageSum() != null && mngCost.getIndividualUsageSum() > 0)
+                            ? mngCost.getIndividualUsageSum() / numberOfUnits
+                            : null;
+                    return new MngCostInfo.MonthlyFee(month, individualUsage);
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
+        // 리스트가 비어있으면 null로 변환
+        individualUsageSum = (individualUsageSum == null || individualUsageSum.stream().allMatch(f -> f.fee() == null)) ? null : individualUsageSum;
 
         // #2-4. 공용 관리비를 변환하고 월 기준으로 정렬합니다.
-        List<MngCostInfo.MonthlyFee> totalCommonManagementFeeSum = mngCosts.stream()
+        List<MngCostInfo.MonthlyFee> totalCommonManagementFeeSum = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
-                    long commonFee = defaultIfNull(mngCost.getTotalCommonManagementFeeSum(), 0L);
-                    return new MngCostInfo.MonthlyFee(
-                            month,
-                            numberOfUnits > 0 ? commonFee / numberOfUnits : 0L
-                    );
+                    Long commonFee = (numberOfUnits != null && numberOfUnits > 0 && mngCost.getTotalCommonManagementFeeSum() != null && mngCost.getTotalCommonManagementFeeSum() > 0)
+                            ? mngCost.getTotalCommonManagementFeeSum() / numberOfUnits
+                            : null;
+                    return new MngCostInfo.MonthlyFee(month, commonFee);
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
+        // 리스트가 비어있으면 null로 변환
+        totalCommonManagementFeeSum = (totalCommonManagementFeeSum == null || totalCommonManagementFeeSum.stream().allMatch(f -> f.fee() == null)) ? null : totalCommonManagementFeeSum;
 
         // #2-5. 장충금 월 부과액을 변환하고 월 기준으로 정렬합니다.
-        List<MngCostInfo.MonthlyFee> reserveFundMonthlyCharge = mngCosts.stream()
+        List<MngCostInfo.MonthlyFee> reserveFundMonthlyCharge = (mngCosts == null || mngCosts.isEmpty())
+                ? null
+                : mngCosts.stream()
                 .map(mngCost -> {
                     String occurrenceYearMonth = String.valueOf(mngCost.getOccurrenceYearMonth());
                     String month = occurrenceYearMonth.substring(4, 6);
-                    long reserveFund = defaultIfNull(mngCost.getReserveFundMonthlyCharge(), 0L);
-                    return new MngCostInfo.MonthlyFee(
-                            month,
-                            numberOfUnits > 0 ? reserveFund / numberOfUnits : 0L
-                    );
+                    Long reserveFund = (numberOfUnits != null && numberOfUnits > 0 && mngCost.getReserveFundMonthlyCharge() != null && mngCost.getReserveFundMonthlyCharge() > 0)
+                            ? mngCost.getReserveFundMonthlyCharge() / numberOfUnits
+                            : null;
+                    return new MngCostInfo.MonthlyFee(month, reserveFund);
                 })
                 .sorted(Comparator.comparing(MngCostInfo.MonthlyFee::month)) // 월 기준으로 정렬
                 .collect(Collectors.toList());
+        // 리스트가 비어있으면 null로 변환
+        reserveFundMonthlyCharge = (reserveFundMonthlyCharge == null || reserveFundMonthlyCharge.stream().allMatch(f -> f.fee() == null)) ? null : reserveFundMonthlyCharge;
 
         // #3. MngCostInfo DTO를 빌드하고 반환합니다.
         return MngCostInfo.builder()
-                .year(year) // 연도 추가
+                .year(year)
                 .individualUsageSum(individualUsageSum)
                 .totalCommonManagementFeeSum(totalCommonManagementFeeSum)
                 .reserveFundMonthlyCharge(reserveFundMonthlyCharge)

--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -23,26 +23,29 @@ public class AptServiceImpl implements AptService{
     private final AvgPricesRepository avgPricesRepository;
     private final PlannedAptsRepository plannedAptsRepository;
 
+    // 메인화면 정보 조회
     @Override
     public MainResponse getMainInfo() {
-
         // 함수가 호출 될 때의, 현재 월을 가져옴
         Long currentMonth = (long) LocalDate.now().getMonthValue();
         // Long 타입으로 변환
         Long currentYear = (long) LocalDate.now().getYear();
 
-        //1. 현재 월에 해당하는 AvgPrices 엔티티를 조회하고 값 설정
+        // 1. 현재 월에 해당하는 AvgPrices 엔티티를 조회하고 값 설정
         Long aptAvgPrice = avgPricesRepository.findByMonth(currentMonth)
                 .map(AvgPrices::getAvgPrice)
-                .orElse(0L);
+                .orElse(null); // 0L 대신 null 반환, DB 값이 null 또는 0일 경우 null 처리
+        aptAvgPrice = (aptAvgPrice == null || aptAvgPrice == 0L) ? null : aptAvgPrice;
 
-        //2. 전국 아파트 수 - JpaRepository의 count() 메서드를 호출하여 aptRepository에서 직접 데이터베이스에 저장된 Apts 엔티티의 총 개수를 가져오는 간단한 방법입니다.
+        // 2. 전국 아파트 수 - JpaRepository의 count() 메서드를 호출하여 aptRepository에서 직접 데이터베이스에 저장된 Apts 엔티티의 총 개수를 가져오는 간단한 방법입니다.
         Long aptCount = aptRepository.count();
+        aptCount = (aptCount == null || aptCount == 0L) ? null : aptCount; // 0일 경우 null 처리
 
-        //3. 현재 연도와 월에 해당하는 PlannedApts 엔티티를 조회하고 값 설정
+        // 3. 현재 연도와 월에 해당하는 PlannedApts 엔티티를 조회하고 값 설정
         Long plannedAptCount = plannedAptsRepository.findByYearAndMonth(currentYear, currentMonth)
                 .map(PlannedApts::getCount)
-                .orElse(0L);
+                .orElse(null); // 0L 대신 null 반환, DB 값이 null 또는 0일 경우 null 처리
+        plannedAptCount = (plannedAptCount == null || plannedAptCount == 0L) ? null : plannedAptCount;
 
         // MainResponse 객체를 생성하여 반환
         return MainResponse.of(aptAvgPrice, aptCount, plannedAptCount);


### PR DESCRIPTION
## 📌 이슈 번호
> #62 
## 💬 리뷰 포인트
> 정보조회시, DB에 저장되지 않는 값이나, 기본값으로 저장된 값들을
전부 NULL 값으로 반환하도록 코드 수정
## 🚀 상세 설명
> 도커 환경에서, 각 API 호출 시 성공화면이 아래와 같습니다.
## 📸 스크린샷
[아파트 기본 정보조회] -- null 값 정상 출력 확인 가능
![스크린샷 2025-03-08 101135](https://github.com/user-attachments/assets/6d61effb-519f-49bc-b487-700ad52a1d03)


[아파트 상세 정보 조회] -- null 값 정상 출력 확인 가능
![스크린샷 2025-03-08 101219](https://github.com/user-attachments/assets/ce655ead-5528-48b4-b2c3-5b7af550402c)


[관리비 정보 조회] -- null 값 정상 출력 확인 가능
![스크린샷 2025-03-08 101350](https://github.com/user-attachments/assets/92f738b0-94c3-4b61-a78e-d1fb9bc5d885)


[메인화면 조회] -- null 값 정상 출력 확인 가능
![스크린샷 2025-03-08 105602](https://github.com/user-attachments/assets/da9445ff-1c38-40ae-8108-b2de6451fe20)


## 📢 노트
