### PR TITLE
:recycle: Feat[#20]: AptServiceImpl 의 메인화면 정보 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
+++ b/src/main/java/com/myapt/domain/apt/service/AptServiceImpl.java
@@ -30,26 +30,26 @@ public class AptServiceImpl implements AptService{
         Long currentYear = (long) LocalDate.now().getYear();
         Long currentMonth = (long) LocalDate.now().getMonthValue();
 
-        // 1. 현재 월에 해당하는 AvgPrices 엔티티를 조회하고 값 설정
-        Long aptAvgPrice = avgPricesRepository.findByYearAndMonth(currentYear,currentMonth)
-                .map(AvgPrices::getAvgPrice)
-                .orElse(null); // DB 값이 null일 경우 null 반환
+        // 1. DB에서 가장 최근 연도와 월에 해당하는 AvgPrices 엔티티를 조회하고 값 설정
+        Optional<AvgPrices> latestAvgPriceOpt = avgPricesRepository.findTopByOrderByYearDescMonthDesc();
+        Long aptAvgPrice = latestAvgPriceOpt.map(AvgPrices::getAvgPrice).orElse(null); // 평균 가격
+        Long aptAvgPriceMonth = latestAvgPriceOpt.map(AvgPrices::getMonth).orElse(null); // 가장 최근 월
         aptAvgPrice = (aptAvgPrice == null || aptAvgPrice == 0L) ? null : aptAvgPrice;
 
         // 2. 전국 아파트 수 - JpaRepository의 count() 메서드로 Apts 엔티티 총 개수 조회
         Long aptCount = aptRepository.count();
-        aptCount = (aptCount == null || aptCount == 0L) ? null : aptCount; // 0일 경우 null 처리
+        aptCount = (aptCount == null || aptCount == 0L) ? null : aptCount;
 
         // 3. 현재 연도와 월에 해당하는 PlannedApts 엔티티를 조회하고 값 설정
         Long plannedAptCount = plannedAptsRepository.findByYearAndMonth(currentYear, currentMonth)
                 .map(PlannedApts::getCount)
-                .orElse(null); // DB 값이 null일 경우 null 반환
+                .orElse(null);
         plannedAptCount = (plannedAptCount == null || plannedAptCount == 0L) ? null : plannedAptCount;
 
         // MainResponse 객체를 생성하여 반환
         return MainResponse.of(
                 aptAvgPrice,
-                currentMonth,
+                aptAvgPriceMonth, // 가장 최근 월로 변경
                 aptCount,
                 plannedAptCount,
                 currentYear,


### PR DESCRIPTION
## 📌 이슈 번호
> #20 
## 💬 리뷰 포인트
>  메인화면 조회시, '월 평균 아파트 매매가 & 월' 데이터 반환 리팩토링
## 🚀 상세 설명
> '월 평균 아파트 매매가'  데이터의 aptAvgPriceMonth 와 aptAvgPrices 는 보통 한 달전의 내용이 최근 자료이기 때문에,
 메인화면 정보 조회 API 호출 시, 해당 정보들이 저장된 DB를 '월'과 '연도'를 내림차순으로 정렬 했을 시에, 
 가장 최상단의 자료를 반환하는 로직으로 리펙토링 함
## 📸 스크린샷
[DB에 저장된 '월 평균 아파트매매가' 테이블]
![스크린샷 2025-03-21 203855](https://github.com/user-attachments/assets/78bac176-588d-42a8-a6bb-5e32e54958ea)

[메인화면 정보 조회 시, 내림차순 정렬 시 가장 최상단의 데이터가 출력됨]
![스크린샷 2025-03-21 203024](https://github.com/user-attachments/assets/9ce47f3f-46c9-4d6b-bda5-e3a9372b64d4)

## 📢 노트
