### PR TITLE
Fix[#72] 뉴스 HTML 문서 미수집 시 플랫폼,이미지 매핑 오류 수정

### DIFF
--- a/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
+++ b/src/main/java/com/myapt/domain/news/dto/NewsSummaryDto.java
@@ -1,15 +1,17 @@
 package com.myapt.domain.news.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
 import org.jsoup.nodes.Document;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.myapt.domain.news.enums.NewsPlatform;
 import com.myapt.domain.news.util.JsoupCrawling;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
-import java.time.OffsetDateTime;
 
 @Getter
 @Slf4j
@@ -19,6 +21,8 @@ public class NewsSummaryDto {
 	private String title;
 	@JsonSetter("link")
 	private String link;
+	@JsonSetter("originallink")
+	private String originalLink;
 	@JsonSetter("description")
 	private String description;
 	@JsonSetter("pubDate")
@@ -34,34 +38,35 @@ public class NewsSummaryDto {
 	*/
 	public NewsCrawlingResponse toNewsResponseDto(JsoupCrawling jsoupCrawling) {
 		// 뉴스 링크를 통해 html 문서 가져옴
-		Document document = jsoupCrawling.getDocument(link);
-		if (document == null) {
-			// document가 null인 경우 기본 값 또는 원본 데이터를 사용하여 응답 생성
-			return NewsCrawlingResponse.builder()
-				.platform("Naver")
-				.imageLink(link)
-				.title(title)
-				.link(link)
-				.description(description)
-				.pubDate(pubDate)
-				.build();
+		Optional<Document> document = jsoupCrawling.getDocument(link);
+
+		String platform;
+		String imageLink = null;
+		String newsTitle = title;
+		String newsContent = description;
+
+		if (document.isPresent()) {
+			// html 문서를 가져온 경우, 문서에서 언론사, 이미지, 제목, 내용을 가져옵니다
+			platform = jsoupCrawling.getPlatform(document.get());
+			imageLink = jsoupCrawling.getImageUrl(document.get());
+			newsTitle = jsoupCrawling.getTitle(document.get());
+			newsContent = jsoupCrawling.getContent(document.get(), 255);
+		} else {
+			// html 문서를 못 가져온 경우, 언론사는 네이버뉴스 url 에서 언론사별 고유한 값을 통해 추출합니다.
+			// https://n.news.naver.com/mnews/article/055/0001239771?sid=101 의 경우 055가 언론사 고유값에 해당함
+			Optional<NewsPlatform> newsPlatform = NewsPlatform.fromCode(link.split("/")[5]);
+			// 만약 NewsPlatform에 없는 값이라면, 언론사 사이트의 도메인을 가져와 임시로 platform에 저장하고
+			// 코드 수정을 통해 NewsPlatform에 해당 언론사를 추가합니다
+			platform = newsPlatform.map(NewsPlatform::getName)
+				.orElseGet(() -> originalLink.split("/")[2]);
 		}
 
-		// html 문서에서 플랫폼 추출
-		String extractedPlatform = jsoupCrawling.getPlatform(document);
-		// html 문서에서 이미지 url 추출
-		String extractedImageLink = jsoupCrawling.getImageUrl(document);
-		// html 문서에서 제목 추출
-		String extractedTitle = jsoupCrawling.getTitle(document);
-		// html 문서에서 본문 추출(최대 길이 설정 가능)
-		String extractedContent = jsoupCrawling.getContent(document, 255);
-
 		return NewsCrawlingResponse.builder()
-			.platform((extractedPlatform != null) ? extractedPlatform : "Naver")
-			.imageLink((extractedImageLink != null) ? extractedImageLink : link)
-			.title((extractedTitle != null) ? extractedTitle : title)
+			.platform(platform)
+			.imageLink(imageLink)
+			.title(newsTitle)
 			.link(link)
-			.description((extractedContent != null) ? extractedContent : description)
+			.description(newsContent)
 			.pubDate(pubDate)
 			.build();
 	}

--- a/src/main/java/com/myapt/domain/news/enums/NewsPlatform.java
+++ b/src/main/java/com/myapt/domain/news/enums/NewsPlatform.java
@@ -1,0 +1,99 @@
+package com.myapt.domain.news.enums;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import lombok.Getter;
+
+public enum NewsPlatform {
+	YNA("001", "연합뉴스"),
+	PRESSIAN("002", "프레시안"),
+	NEWSIS("003", "뉴시스"),
+	KMIB("005", "국민일보"),
+	MEDIATODAY("006", "미디어오늘"),
+	MT("008", "머니투데이"),
+	MK("009", "매일경제"),
+	SEDAILY("011", "서울경제"),
+	FNNEWS("014", "파이낸셜뉴스"),
+	HANKYUNG("015", "한국경제"),
+	HERALD_CORP("016", "헤럴드경제"),
+	EDAILY("018", "이데일리"),
+	DONGA("020", "동아일보"),
+	MUNHWA("021", "문화일보"),
+	SEGYE("022", "세계일보"),
+	CHOSUN("023", "조선일보"),
+	MK_ECONOMY("024", "매경이코노미"),
+	JOONGANG("025", "중앙일보"),
+	HANI("028", "한겨레"),
+	DT("029", "디지털타임스"),
+	ETNEWS("030", "전자신문"),
+	INEWS24("031", "아이뉴스24"),
+	KHAN("032", "경향신문"),
+	HANI_21("036", "한겨례21"),
+	WEEKLY_DONGA("037", "주간동아"),
+	OHMY_NEWS("047", "오마이뉴스"),
+	HANKYUNG_BUSINESS("050", "한경비즈니스"),
+	YTN("052", "YTN"),
+	WEEKLY_CHOSUN("053", "주간조선"),
+	SBS("055", "SBS"),
+	KBS("056", "KBS"),
+	MBN("057", "MBN"),
+	NOCUT_NEWS("079", "노컷뉴스"),
+	SEOUL_NEWS("081", "서울신문"),
+	BUSAN_ILBO("082", "부산일보"),
+	KWNEWS("087", "강원일보"),
+	IMAEIL("088", "매일신문"),
+	ZDNET_KOREA("092", "지디넷코리아"),
+	STAR_NEWS("108", "스타뉴스"),
+	MYDAILY("117", "마이데일리"),
+	DAILIAN("119", "데일리안"),
+	JOSE_ILBO("123", "조세일보"),
+	DIGITAL_DAILY("138", "디지털데일리"),
+	IMBC_MBC("214", "MBC"),
+	WOWTV("215", "한국경제TV"),
+	ISPLUS("241", "일간스포츠"),
+	ECONOMIST("243", "이코노미스트"),
+	SHINDONGA("262", "신동아"),
+	ASIAE("277", "아시아경제"),
+	BLOTER("293", "블로터"),
+	WOMEN_NEWS("310", "여성신문"),
+	JOONGANG_SUNDAY("353", "중앙SUNDAY"),
+	CHOSUN_BIZ("366", "조선비즈"),
+	SBS_BIZ("374", "SBS Biz"),
+	MONEY_S("417", "머니S"),
+	NEWS1("421", "뉴스1"),
+	YONHAP_TV("422", "연합뉴스TV"),
+	JTBC("437", "JTBC"),
+	TV_CHOSUN("448", "TV조선"),
+	CHANNEL_A("449", "채널A"),
+	SPORTSSEOUL("468", "스포츠서울"),
+	HANKOOK_ILBO("469", "한국일보"),
+	SISAJOURNAL("586", "시사저널"),
+	TF("629", "더팩트"),
+	KOREA_CENTRAL_DAILY("640", "코리아중앙데일리"),
+	BIZWATCH("648", "비즈워치"),
+	KANGWON_MIN_ILBO("654", "강원도민일보"),
+	DAEJEON_ILBO("656", "대전일보"),
+	DAEGU_MBC("657", "대구MBC"),
+	GUKJE_SINMUN("658", "국제신문"),
+	JEONJU_MBC("659", "전주MBC"),
+	KBC_GWANGJU("660", "kbc광주방송"),
+	JIBS("661", "JIBS"),
+	THE_SCOOP("665", "더스쿠프"),
+	KYEONGGI("666", "경기일보");
+
+	private final String code;
+	@Getter
+	private final String name;
+
+	NewsPlatform(String code, String name) {
+		this.code = code;
+		this.name = name;
+	}
+
+	public static Optional<NewsPlatform> fromCode(String code) {
+		return Arrays.stream(NewsPlatform.values())
+			.filter(source -> source.code.equals(code))
+			.findFirst();
+	}
+}

--- a/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
+++ b/src/main/java/com/myapt/domain/news/util/JsoupCrawling.java
@@ -1,13 +1,20 @@
 package com.myapt.domain.news.util;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.util.Optional;
 
+import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
+import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class JsoupCrawling {
 	/*
 	connection을 생성하여 Document를 반환
@@ -20,12 +27,22 @@ public class JsoupCrawling {
 	url을 통해 html 문서를 가져오는 메서드
 	연결 실패 시, null 반환
 	 */
-	public Document getDocument(String url) {
+	public Optional<Document> getDocument(String url) {
 		try {
-			return getConnection(url);
+			return Optional.of(getConnection(url));
+		} catch (MalformedURLException e) {
+			log.warn("잘못된 URL 형식: {}. 에러: {}", url, e.getMessage());
+		} catch (HttpStatusException e) {
+			log.warn("HTTP 상태 오류 코드 ({}): {} URL 요청 중 발생: {}",
+				e.getStatusCode(), e.getMessage(), url);
+		} catch (UnsupportedMimeTypeException e) {
+			log.warn("지원되지 않는 MIME 타입: {}. 에러: {}", url, e.getMessage());
+		} catch (SocketTimeoutException e) {
+			log.warn("URL 연결 시간 초과: {}. 에러: {}", url, e.getMessage());
 		} catch (IOException e) {
-			return null;
+			log.warn("URL 연결 중 IO 예외 발생: {}. 에러: {}", url, e.getMessage());
 		}
+		return Optional.empty();
 	}
 
 	public Optional<Elements> getJsoupElements(String url, String query) {


### PR DESCRIPTION
## 📌 이슈 번호
> #72 
## 💬 리뷰 포인트
- 문서 미수집 시 NewsPlatform 적용 로직 검토
- NewsPlatform Enum에 없는 언론사의 경우 DB의 News 테이블의 platform 컬럼에 언론사 도메인을 임시로 저장하는 처리 방식 검
## 🚀 상세 설명
- 뉴스 링크에서 HTML 문서를 가져오지 못한 경우, news테이블의 platform과 image 컬럼에 저장되는 값 수정하였습니다.
- platform은 뉴스 링크(link)에서 추출한 언론사 코드를 통해 NewsPlatform에 등록된 코드가 있다면, 해당 언론사의 이름을 사용하도록 변경하였습니다.
- 만약 NewsPlatform에 해당 코드가 없다면, API 응답 중 원본 링크(originallink)에서 도메인을 추출해 임시 플랫폼 값으로 사용합니다.
- 추후 DB에 새로운 언론사 도메인이 발견되면, NewsPlatform에 해당 언론사를 추가하하겠습니다.
- image는 null 값을 저장하도록 수정했습니다.
## 📸 스크린샷

## 📢 노트