### PR TITLE
Refactor[#76] 뉴스 중복 문제 해결 

### DIFF
--- a/src/main/java/com/myapt/domain/news/controller/NewsController.java
+++ b/src/main/java/com/myapt/domain/news/controller/NewsController.java
@@ -39,4 +39,16 @@ public class NewsController {
 		}
 		return new ResTemplate<>(HttpStatus.OK, "뉴스 조회 성공", data);
 	}
+
+	@PostMapping("/saveNews")
+	public ResTemplate<NewsResponse> saveNews() {
+		newsService.crawlAndSaveNews();
+		return new ResTemplate<>(HttpStatus.OK, "뉴스 저장 성공");
+	}
+
+	@PostMapping("/saveNewsJDBC")
+	public ResTemplate<NewsResponse> saveNewsJDBC() {
+		newsService.crawlAndSaveNews();
+		return new ResTemplate<>(HttpStatus.OK, "뉴스 저장 성공");
+	}
 }

--- a/src/main/java/com/myapt/domain/news/controller/NewsController.java
+++ b/src/main/java/com/myapt/domain/news/controller/NewsController.java
@@ -39,16 +39,4 @@ public class NewsController {
 		}
 		return new ResTemplate<>(HttpStatus.OK, "뉴스 조회 성공", data);
 	}
-
-	@PostMapping("/saveNews")
-	public ResTemplate<NewsResponse> saveNews() {
-		newsService.crawlAndSaveNews();
-		return new ResTemplate<>(HttpStatus.OK, "뉴스 저장 성공");
-	}
-
-	@PostMapping("/saveNewsJDBC")
-	public ResTemplate<NewsResponse> saveNewsJDBC() {
-		newsService.crawlAndSaveNews();
-		return new ResTemplate<>(HttpStatus.OK, "뉴스 저장 성공");
-	}
 }

--- a/src/main/java/com/myapt/domain/news/entity/News.java
+++ b/src/main/java/com/myapt/domain/news/entity/News.java
@@ -31,6 +31,7 @@ public class News {
 
 	private String content; // 뉴스 본문
 
+	@Column(unique = true)
 	private String url; // 뉴스 url
 
 	private OffsetDateTime pubDate; // 뉴스 출판 날짜

--- a/src/main/java/com/myapt/domain/news/repository/NewsJdbcRepository.java
+++ b/src/main/java/com/myapt/domain/news/repository/NewsJdbcRepository.java
@@ -1,0 +1,29 @@
+package com.myapt.domain.news.repository;
+
+import com.myapt.domain.news.entity.News;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsJdbcRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public void batchInsertOrIgnore(List<News> news) {
+        String sql = "INSERT INTO news (id, type, platform, image, title, content, url, pub_date, created_at, updated_at) " +
+                "VALUES (:id, :type, :platform, :image, :title, :content, :url, :pubDate, :createdAt, :updatedAt) " +
+                "ON DUPLICATE KEY UPDATE url = url";
+
+        SqlParameterSource[] params = news.stream()
+                .map(BeanPropertySqlParameterSource::new)
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(sql, params);
+    }
+}

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.myapt.domain.news.repository.NewsJdbcRepository;
 import com.myapt.domain.defect.exception.DefectAptInvalidException;
 import com.myapt.domain.news.exception.NewsNotFoundException;
 import org.springframework.data.domain.Page;
@@ -34,17 +35,17 @@ public class NewsServiceImpl implements NewsService {
 	private final NewsApiResponseRepository newsApiResponseRepository;
 	private final NewsRepository newsRepository;
 
-	// 부실 뉴스 캐시 역할을 하는 set (동시 접근 대비 동기화)
+//	 부실 뉴스 캐시 역할을 하는 set (동시 접근 대비 동기화)
 	private final LinkedHashSet<String> defectNewsUrlCache = new LinkedHashSet<>();
-	// 캐시 최대 용량 (API 조회 크기의 2배)
 	private final int DEFECT_CACHE_CAPACITY = 100;
+	private final NewsJdbcRepository newsJdbcRepository;
 
 	/*
 	 30분마다 실행되는 스케줄러 메서드
 	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
 	 */
 	@Override
-	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
+//	@Scheduled(fixedRate = 18000)  // 30분 = 30 * 60 * 1000 밀리초
 	public void crawlAndSaveNews() {
 		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
 
@@ -219,5 +220,67 @@ public class NewsServiceImpl implements NewsService {
 			.url(news.getUrl())
 			.createAt(news.getCreateAt())
 			.build();
+	}
+
+	/*
+	 30분마다 실행되는 스케줄러 메서드
+	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
+	 */
+//	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
+	public void crawlAndSaveNewsJDBC() {
+		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
+
+		try {
+			processDefectNewsJDBC();
+			processNormalNewsJDBC();
+		} catch (Exception e) {
+			log.error("Error during scheduled news crawling", e);
+		}
+	}
+
+	/*
+	 부실(Defect) 뉴스 처리
+	 1. 부실 뉴스 API 조회
+	 2. DB에 이미 저장된 뉴스와 중복 제거
+	 3. 캐시에 신규 부실 뉴스 URL 추가 (용량 초과 시 오래된 URL 삭제)
+	 4. DB에 부실 뉴스 저장
+	 */
+	private void processDefectNewsJDBC() {
+		String defectKeyword = "아파트 부실 시공 공사";
+
+		// 부실 뉴스 조회 - 가장 최근 뉴스가 첫번째, 가장 오래된 뉴스가 마지막
+		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
+				.orElseThrow(NewsNotFoundException::newsNotFound);
+		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoList();
+
+		saveNewsJDBC(defectNewsList, "부실 아파트");
+		log.info("Completed defect news crawling and saving.");
+	}
+
+	/*
+	 일반 뉴스 처리
+	 1. 일반 뉴스 API 조회
+	 2. DB에 이미 저장된 뉴스와 중복 제거
+	 3. 부실 뉴스 캐시 URL에 포함된 뉴스 제거 (중복 제거)
+	 4. DB에 일반 뉴스 저장
+	 */
+	private void processNormalNewsJDBC() {
+		String normalKeyword = "아파트 부동산";
+
+		// 일반 뉴스 조회
+		NewsApiResponse normalNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(normalKeyword)
+				.orElseThrow(NewsNotFoundException::newsNotFound);
+		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoList();
+
+		// 일반 뉴스 DB 저장
+		saveNewsJDBC(normalNewsList, "아파트");
+		log.info("Completed normal news crawling and saving.");
+	}
+
+	private void saveNewsJDBC(List<NewsCrawlingResponse> newsResponseDtos, String newsType) {
+		List<News> newsList = newsResponseDtos.stream()
+				.map(news -> mapToNewsEntity(news, newsType))
+				.collect(Collectors.toList());
+		newsJdbcRepository.batchInsertOrIgnore(newsList);
 	}
 }

--- a/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/myapt/domain/news/service/NewsServiceImpl.java
@@ -1,9 +1,7 @@
 package com.myapt.domain.news.service;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.myapt.domain.news.repository.NewsJdbcRepository;
@@ -34,10 +32,6 @@ public class NewsServiceImpl implements NewsService {
 
 	private final NewsApiResponseRepository newsApiResponseRepository;
 	private final NewsRepository newsRepository;
-
-//	 부실 뉴스 캐시 역할을 하는 set (동시 접근 대비 동기화)
-	private final LinkedHashSet<String> defectNewsUrlCache = new LinkedHashSet<>();
-	private final int DEFECT_CACHE_CAPACITY = 100;
 	private final NewsJdbcRepository newsJdbcRepository;
 
 	/*
@@ -45,7 +39,7 @@ public class NewsServiceImpl implements NewsService {
 	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
 	 */
 	@Override
-//	@Scheduled(fixedRate = 18000)  // 30분 = 30 * 60 * 1000 밀리초
+	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
 	public void crawlAndSaveNews() {
 		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
 
@@ -60,25 +54,16 @@ public class NewsServiceImpl implements NewsService {
 	/*
 	 부실(Defect) 뉴스 처리
 	 1. 부실 뉴스 API 조회
-	 2. DB에 이미 저장된 뉴스와 중복 제거
-	 3. 캐시에 신규 부실 뉴스 URL 추가 (용량 초과 시 오래된 URL 삭제)
-	 4. DB에 부실 뉴스 저장
+	 2. DB에 뉴스 url 기준으로 중복 없이 부실 아파트 뉴스 저장
 	 */
 	private void processDefectNews() {
 		String defectKeyword = "아파트 부실 시공 공사";
 
 		// 부실 뉴스 조회 - 가장 최근 뉴스가 첫번째, 가장 오래된 뉴스가 마지막
 		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
-			.orElseThrow(NewsNotFoundException::newsNotFound);
+				.orElseThrow(NewsNotFoundException::newsNotFound);
 		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoList();
 
-		// DB에 이미 저장된 뉴스와 중복되는 항목 제거
-		defectNewsList = filterDuplicateNewsInDB(defectNewsList, "부실 아파트");
-
-		// 캐시(set)에 신규 부실 뉴스 추가 (용량 초과 시 오래된 요소 삭제)
-		addToDefectCache(defectNewsList);
-
-		// 부실 뉴스 DB 저장
 		saveNews(defectNewsList, "부실 아파트");
 		log.info("Completed defect news crawling and saving.");
 	}
@@ -86,67 +71,19 @@ public class NewsServiceImpl implements NewsService {
 	/*
 	 일반 뉴스 처리
 	 1. 일반 뉴스 API 조회
-	 2. DB에 이미 저장된 뉴스와 중복 제거
-	 3. 부실 뉴스 캐시 URL에 포함된 뉴스 제거 (중복 제거)
-	 4. DB에 일반 뉴스 저장
+	 2. DB에 뉴스 url 기준으로 중복 없이 일반 뉴스 저장
 	 */
 	private void processNormalNews() {
 		String normalKeyword = "아파트 부동산";
 
 		// 일반 뉴스 조회
 		NewsApiResponse normalNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(normalKeyword)
-			.orElseThrow(NewsNotFoundException::newsNotFound);
+				.orElseThrow(NewsNotFoundException::newsNotFound);
 		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoList();
-
-		// DB에 이미 저장된 뉴스 제거
-		normalNewsList = filterDuplicateNewsInDB(normalNewsList, "아파트");
-
-		// 캐시(set)에 저장된 부실 뉴스와 중복되는 일반 뉴스 제거
-		normalNewsList = filterDuplicateNewsInDefectCache(normalNewsList);
 
 		// 일반 뉴스 DB 저장
 		saveNews(normalNewsList, "아파트");
 		log.info("Completed normal news crawling and saving.");
-	}
-
-	/*
-	 신규 부실 뉴스의 URL을 캐시에 추가하는 메서드
-	 만약 캐시가 최대 용량을 초과하면, 오래된 URL부터 삭제 후 추가
-	 */
-	private void addToDefectCache(List<NewsCrawlingResponse> newsList) {
-		int removeSize = defectNewsUrlCache.size() + newsList.size() - DEFECT_CACHE_CAPACITY;
-		for (int i = 0; i < removeSize; i++) {
-			defectNewsUrlCache.removeFirst();
-		}
-		List<String> urlList = newsList.stream().map(NewsCrawlingResponse::getLink).toList();
-		defectNewsUrlCache.addAll(urlList);
-	}
-
-	/*
-	 DB에 이미 저장된 뉴스와 비교하여 중복되는 항목을 제거
-	 뉴스 URL 기준으로 중복 여부를 판단
-	 */
-	private List<NewsCrawlingResponse> filterDuplicateNewsInDB(List<NewsCrawlingResponse> newsList, String newsType) {
-		// DB에 저장된 같은 타입의 뉴스 중에서 가장 최근 뉴스의 URL 가져온다
-		Optional<News> lastNewsOpt = newsRepository.findFirstByTypeOrderByPubDateDesc(newsType);
-		if (lastNewsOpt.isEmpty()) {
-			return newsList;
-		}
-		String lastNewsUrl = lastNewsOpt.get().getUrl();
-
-		// 뉴스 리스트에서 DB에 저장된 최신 뉴스(및 그 이전 뉴스)는 제거
-		return newsList.stream()
-				.takeWhile(news -> !news.getLink().equals(lastNewsUrl))
-				.toList();
-	}
-
-	/*
-	 일반 뉴스 리스트에서 부실 뉴스 캐시 URL과 중복되는 뉴스를 제거
-	 */
-	private List<NewsCrawlingResponse> filterDuplicateNewsInDefectCache(List<NewsCrawlingResponse> newsList) {
-		return newsList.stream()
-			.filter(news -> !defectNewsUrlCache.contains(news.getLink()))
-			.collect(Collectors.toList());
 	}
 
 	/**
@@ -162,16 +99,16 @@ public class NewsServiceImpl implements NewsService {
 		if (page <= 0) {
 			throw DefectAptInvalidException.pageInfoInvalid();
 		}
-		if(size <= 0 || size > 20) {
+		if (size <= 0 || size > 20) {
 			throw DefectAptInvalidException.numInvalid();
 		}
 
 		Sort sorting = Sort.by("createdAt");
 		if ("asc".equalsIgnoreCase(sort)) {
 			sorting = sorting.ascending();
-		} else if("desc".equalsIgnoreCase(sort)) {
+		} else if ("desc".equalsIgnoreCase(sort)) {
 			sorting = sorting.descending();
-		}else {
+		} else {
 			throw DefectAptInvalidException.sortTypeInvalid();
 		}
 
@@ -184,103 +121,41 @@ public class NewsServiceImpl implements NewsService {
 		}
 
 		List<NewsRequest> newsList = newsPage.getContent().stream()
-			.map(this::convertToDTO)
-			.collect(Collectors.toList());
+				.map(this::convertToDTO)
+				.collect(Collectors.toList());
 
 		return new NewsResponse(newsList, newsPage.getTotalElements());
 	}
 
 	private void saveNews(List<NewsCrawlingResponse> newsResponseDtos, String newsType) {
 		List<News> newsList = newsResponseDtos.stream()
-			.map(news -> mapToNewsEntity(news, newsType))
-			.collect(Collectors.toList());
-		newsRepository.saveAll(newsList);
+				.map(news -> mapToNewsEntity(news, newsType))
+				.collect(Collectors.toList());
+		newsJdbcRepository.batchInsertOrIgnore(newsList);
 	}
 
 	private News mapToNewsEntity(NewsCrawlingResponse dto, String type) {
 		return News.builder()
-			.type(type)
-			.platform(dto.getPlatform())
-			.image(dto.getImageLink())
-			.title(dto.getTitle())
-			.content(dto.getDescription())
-			.url(dto.getLink())
-			.createdAt(LocalDateTime.now())
-			.updatedAt(LocalDateTime.now())
-			.pubDate(dto.getPubDate())
-			.build();
+				.type(type)
+				.platform(dto.getPlatform())
+				.image(dto.getImageLink())
+				.title(dto.getTitle())
+				.content(dto.getDescription())
+				.url(dto.getLink())
+				.createdAt(LocalDateTime.now())
+				.updatedAt(LocalDateTime.now())
+				.pubDate(dto.getPubDate())
+				.build();
 	}
 
 	private NewsRequest convertToDTO(News news) {
 		return NewsRequest.builder()
-			.platform(news.getPlatform())
-			.image(news.getImage())
-			.title(news.getTitle())
-			.content(news.getContent())
-			.url(news.getUrl())
-			.createAt(news.getCreateAt())
-			.build();
-	}
-
-	/*
-	 30분마다 실행되는 스케줄러 메서드
-	 부실 뉴스와 일반 뉴스를 주기적으로 크롤링하여 DB에 저장함
-	 */
-//	@Scheduled(fixedRate = 1800000)  // 30분 = 30 * 60 * 1000 밀리초
-	public void crawlAndSaveNewsJDBC() {
-		log.info("Starting scheduled news crawling at {}", LocalDateTime.now());
-
-		try {
-			processDefectNewsJDBC();
-			processNormalNewsJDBC();
-		} catch (Exception e) {
-			log.error("Error during scheduled news crawling", e);
-		}
-	}
-
-	/*
-	 부실(Defect) 뉴스 처리
-	 1. 부실 뉴스 API 조회
-	 2. DB에 이미 저장된 뉴스와 중복 제거
-	 3. 캐시에 신규 부실 뉴스 URL 추가 (용량 초과 시 오래된 URL 삭제)
-	 4. DB에 부실 뉴스 저장
-	 */
-	private void processDefectNewsJDBC() {
-		String defectKeyword = "아파트 부실 시공 공사";
-
-		// 부실 뉴스 조회 - 가장 최근 뉴스가 첫번째, 가장 오래된 뉴스가 마지막
-		NewsApiResponse defectNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(defectKeyword)
-				.orElseThrow(NewsNotFoundException::newsNotFound);
-		List<NewsCrawlingResponse> defectNewsList = defectNewsApiResponse.getNewsResponseDtoList();
-
-		saveNewsJDBC(defectNewsList, "부실 아파트");
-		log.info("Completed defect news crawling and saving.");
-	}
-
-	/*
-	 일반 뉴스 처리
-	 1. 일반 뉴스 API 조회
-	 2. DB에 이미 저장된 뉴스와 중복 제거
-	 3. 부실 뉴스 캐시 URL에 포함된 뉴스 제거 (중복 제거)
-	 4. DB에 일반 뉴스 저장
-	 */
-	private void processNormalNewsJDBC() {
-		String normalKeyword = "아파트 부동산";
-
-		// 일반 뉴스 조회
-		NewsApiResponse normalNewsApiResponse = newsApiResponseRepository.getNewsApiResponseDto(normalKeyword)
-				.orElseThrow(NewsNotFoundException::newsNotFound);
-		List<NewsCrawlingResponse> normalNewsList = normalNewsApiResponse.getNewsResponseDtoList();
-
-		// 일반 뉴스 DB 저장
-		saveNewsJDBC(normalNewsList, "아파트");
-		log.info("Completed normal news crawling and saving.");
-	}
-
-	private void saveNewsJDBC(List<NewsCrawlingResponse> newsResponseDtos, String newsType) {
-		List<News> newsList = newsResponseDtos.stream()
-				.map(news -> mapToNewsEntity(news, newsType))
-				.collect(Collectors.toList());
-		newsJdbcRepository.batchInsertOrIgnore(newsList);
+				.platform(news.getPlatform())
+				.image(news.getImage())
+				.title(news.getTitle())
+				.content(news.getContent())
+				.url(news.getUrl())
+				.createAt(news.getCreateAt())
+				.build();
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #76

## 💬 리뷰 포인트
- News 엔티티의 url 필드에 unique 제약조건 추가
- Bulk insert를 통한 DB 삽입
- 중복 뉴스 처리를 위한 ON DUPLICATE KEY UPDATE 적용

## 🚀 상세 설명
- **UNIQUE 제약조건 추가:** News 엔티티의 url 필드에 unique 제약조건을 추가하여 중복 데이터 삽입을 데이터베이스에서 방지합니다.
- **중복 데이터 처리:** 중복 뉴스 발생 시, 기존 값을 유지하도록 ON DUPLICATE KEY UPDATE 옵션을 활용해 중복 처리했습니다. 
- **Bulk Insert 도입:** 기존의 saveAll() 방식 대신 하나의 쿼리로 여러 데이터를 동시에 삽입하는 Bulk Insert 방식을 적용하여 DB 쿼리 발생 횟수를 줄였습니다.
- **JDBC 옵션 설정:** application.yml, Datasource URL에 `rewriteBatchedStatements=true` 옵션을 추가하여 여러 쿼리를 하나의 벌크 쿼리로 재작성하도록 설정하여 데이터베이스 디스크 I/O 작업량이 감소했습니다.

## 📸 스크린샷
JDBC로 Bulk Insert 구현
![image](https://github.com/user-attachments/assets/a84f8416-02a9-431a-8e14-e6124d6c27ab)

Bulk Insert 성능 비교 결과 스크린샷 (워크벤치 대시보드)
![image](https://github.com/user-attachments/assets/6495a91c-356b-4eec-b192-e3024eb5c7db)
- `rewriteBatchedStatements=true` 미적용 시 초당 InnoDB Disk Writes: 130~140 kb/s

![image](https://github.com/user-attachments/assets/c5b5418f-4e18-41bf-b06a-8eeb4fd5cd52)
- `rewriteBatchedStatements=true` 적용 시 초당 InnoDB Disk Writes: 20~40 kb/s

## 📢 노트
