### PR TITLE
Fix[#77]: 부실아파트 정보 중 없는 정보에 대한 null 반환

### DIFF
--- a/src/main/java/com/myapt/domain/defect/service/DefectServiceImpl.java
+++ b/src/main/java/com/myapt/domain/defect/service/DefectServiceImpl.java
@@ -47,30 +47,30 @@ public class DefectServiceImpl implements DefectService {
 
 		// 건물 정보 생성
 		DefectAptInfo aptInfo = DefectAptInfo.of(
-			apt.getAptNm(),
-			apt.getRdnmadr(),
-			defectApt.getZipcode()
+			apt.getAptNm() != null ? apt.getAptNm() : null,
+			apt.getRdnmadr() != null ? apt.getRdnmadr() : null,
+			defectApt.getZipcode() != null ? defectApt.getZipcode() : null
 		);
 
 		// 기본 정보 생성
 		DefectBasicInfo basicInfo = DefectBasicInfo.of(
-			String.valueOf(apt.getUseAprvYear()),
-			apt.getNmhsh(),
-			defectApt.getDesgnr(),
-			apt.getCnstEntrprsNm(),
-			defectApt.getSprvsr()
+			apt.getUseAprvYear() != null ? String.valueOf(apt.getUseAprvYear()) : null,
+			apt.getNmhsh() != null ? apt.getNmhsh() : null,
+			defectApt.getDesgnr() != null ? defectApt.getDesgnr() : null,
+			apt.getCnstEntrprsNm() != null ? apt.getCnstEntrprsNm() : null,
+			defectApt.getSprvsr() != null ? defectApt.getSprvsr() : null
 		);
 
 		// 건물 구조, 부실 사유 생성
 		DefectBuildInfo buildInfo = DefectBuildInfo.of(
-			apt.getBuldStru(),
-			defectApt.getDefectType()
+			apt.getBuldStru() != null ? apt.getBuldStru() : null,
+			defectApt.getDefectType() != null ? defectApt.getDefectType() : null
 		);
 
 		// 보강 상태, 보강 내용 생성
 		DefectSplmnInfo splmnInfo = DefectSplmnInfo.of(
-			defectApt.getReinfContent(),
-			defectApt.getReinfStatus()
+			defectApt.getReinfContent() != null ? defectApt.getReinfContent() : null,
+			defectApt.getReinfStatus() != null ? defectApt.getReinfStatus() : null
 		);
 
 		return DefectInfoResponse.of(aptInfo, basicInfo, buildInfo, splmnInfo);


### PR DESCRIPTION
## 📌 이슈 번호
> #77 
## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 삼항연산자를 통한 없는 정보 null 표시
## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
- 부실 아파트 정보 중 없는 정보가 있을 경우 null 표시를 해야했는데 삼항연산자를 통하여 없는 정보를 null로 표시하였습니다.

## 📸 스크린샷
> 적용 전(completionDate => "null")
![b](https://github.com/user-attachments/assets/cd740337-9d13-4794-b197-e61712c9932b)


> 적용 후(completionDate => null)
![a](https://github.com/user-attachments/assets/eebf91d2-76de-41b8-a0f0-9b03a454b54a)

## 📢 노트